### PR TITLE
feat: Add Standard Token Contract for Benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +374,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +515,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1494,6 +1524,7 @@ version = "22.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "027cd856171bfd6ad2c0ffb3b7dfe55ad7080fb3050c36ad20970f80da634472"
 dependencies = [
+ "arbitrary",
  "crate-git-revision",
  "ethnum",
  "num-derive",
@@ -1587,7 +1618,11 @@ version = "22.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7ac27d7573e62b745513fa1be8dab7a09b9676a7f39db97164f1d458a344749"
 dependencies = [
+ "arbitrary",
  "bytes-lit",
+ "ctor",
+ "derive_arbitrary",
+ "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
@@ -1645,6 +1680,13 @@ dependencies = [
  "stellar-xdr",
  "syn 2.0.114",
  "thiserror",
+]
+
+[[package]]
+name = "soroban-token-contract"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1710,6 +1752,7 @@ version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce69db907e64d1e70a3dce8d4824655d154749426a6132b25395c49136013e4"
 dependencies = [
+ "arbitrary",
  "base64 0.13.1",
  "crate-git-revision",
  "escape-bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 resolver = "2"
 members = [
     "core",
+    "contracts/token",
 ]

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "soroban-token-contract"
+description = "Soroban Token Contract"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/token/src/admin.rs
+++ b/contracts/token/src/admin.rs
@@ -1,0 +1,17 @@
+use soroban_sdk::{Address, Env};
+use crate::storage_types::DataKey;
+
+pub fn has_administrator(e: &Env) -> bool {
+    let key = DataKey::Admin;
+    e.storage().instance().has(&key)
+}
+
+pub fn read_administrator(e: &Env) -> Address {
+    let key = DataKey::Admin;
+    e.storage().instance().get(&key).unwrap()
+}
+
+pub fn write_administrator(e: &Env, id: &Address) {
+    let key = DataKey::Admin;
+    e.storage().instance().set(&key, id);
+}

--- a/contracts/token/src/allowance.rs
+++ b/contracts/token/src/allowance.rs
@@ -1,0 +1,40 @@
+use crate::storage_types::{AllowanceDataKey, AllowanceValue, DataKey};
+use soroban_sdk::{Address, Env};
+
+pub fn read_allowance(e: &Env, from: Address, spender: Address) -> AllowanceValue {
+    let key = DataKey::Allowance(AllowanceDataKey { from, spender });
+    match e.storage().temporary().get::<_, AllowanceValue>(&key) {
+        Some(allowance) => allowance,
+        None => AllowanceValue {
+            amount: 0,
+            expiration_ledger: 0,
+        },
+    }
+}
+
+pub fn write_allowance(e: &Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32) {
+    let key = DataKey::Allowance(AllowanceDataKey { from, spender });
+    let allowance = AllowanceValue {
+        amount,
+        expiration_ledger,
+    };
+
+    if amount > 0 {
+        e.storage().temporary().set(&key, &allowance);
+        // In newer Soroban versions, we might need to extend TTL, but for this basic logic we just set it.
+        // Assuming standard bump logic handles it or it's manual.
+    } else {
+        e.storage().temporary().remove(&key);
+    }
+}
+
+pub fn spend_allowance(e: &Env, from: Address, spender: Address, amount: i128) {
+    let allowance = read_allowance(e, from.clone(), spender.clone());
+    if allowance.amount < amount {
+        panic!("insufficient allowance");
+    }
+    if allowance.expiration_ledger < e.ledger().sequence() {
+        panic!("allowance expired");
+    }
+    write_allowance(e, from, spender, allowance.amount - amount, allowance.expiration_ledger);
+}

--- a/contracts/token/src/balance.rs
+++ b/contracts/token/src/balance.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::{Address, Env};
+use crate::storage_types::DataKey;
+
+pub fn read_balance(e: &Env, addr: Address) -> i128 {
+    let key = DataKey::Balance(addr);
+    match e.storage().persistent().get::<DataKey, i128>(&key) {
+        Some(balance) => balance,
+        None => 0,
+    }
+}
+
+fn write_balance(e: &Env, addr: Address, amount: i128) {
+    let key = DataKey::Balance(addr);
+    e.storage().persistent().set(&key, &amount);
+}
+
+pub fn receive_balance(e: &Env, addr: Address, amount: i128) {
+    let balance = read_balance(e, addr.clone());
+    write_balance(e, addr, balance + amount); // Assumes no overflow for this example, but production should check
+}
+
+pub fn spend_balance(e: &Env, addr: Address, amount: i128) {
+    let balance = read_balance(e, addr.clone());
+    if balance < amount {
+        panic!("insufficient balance");
+    }
+    write_balance(e, addr, balance - amount);
+}

--- a/contracts/token/src/contract.rs
+++ b/contracts/token/src/contract.rs
@@ -1,0 +1,114 @@
+use crate::admin::{has_administrator, read_administrator, write_administrator};
+use crate::allowance::{read_allowance, spend_allowance, write_allowance};
+use crate::balance::{read_balance, receive_balance, spend_balance};
+use crate::metadata::{read_decimal, read_name, read_symbol, write_decimal, write_name, write_symbol};
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
+
+pub trait TokenTrait {
+    fn initialize(e: Env, admin: Address, decimal: u32, name: String, symbol: String);
+    fn mint(e: Env, to: Address, amount: i128);
+    fn set_admin(e: Env, new_admin: Address);
+    fn allowance(e: Env, from: Address, spender: Address) -> i128;
+    fn approve(e: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32);
+    fn balance(e: Env, id: Address) -> i128;
+    fn transfer(e: Env, from: Address, to: Address, amount: i128);
+    fn transfer_from(e: Env, spender: Address, from: Address, to: Address, amount: i128);
+    fn burn(e: Env, from: Address, amount: i128);
+    fn burn_from(e: Env, spender: Address, from: Address, amount: i128);
+    fn decimals(e: Env) -> u32;
+    fn name(e: Env) -> String;
+    fn symbol(e: Env) -> String;
+}
+
+#[contract]
+pub struct Token;
+
+#[contractimpl]
+impl TokenTrait for Token {
+    fn initialize(e: Env, admin: Address, decimal: u32, name: String, symbol: String) {
+        if has_administrator(&e) {
+            panic!("already initialized");
+        }
+        write_administrator(&e, &admin);
+        write_decimal(&e, decimal);
+        write_name(&e, &name);
+        write_symbol(&e, &symbol);
+    }
+
+    fn mint(e: Env, to: Address, amount: i128) {
+        let admin = read_administrator(&e);
+        admin.require_auth();
+        e.storage().instance().extend_ttl(100, 100); // Simple maintenance of instance storage
+
+        receive_balance(&e, to, amount);
+    }
+
+    fn set_admin(e: Env, new_admin: Address) {
+        let admin = read_administrator(&e);
+        admin.require_auth();
+        e.storage().instance().extend_ttl(100, 100);
+        
+        write_administrator(&e, &new_admin);
+    }
+
+    fn allowance(e: Env, from: Address, spender: Address) -> i128 {
+        e.storage().instance().extend_ttl(100, 100);
+        read_allowance(&e, from, spender).amount
+    }
+
+    fn approve(e: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32) {
+        from.require_auth();
+        e.storage().instance().extend_ttl(100, 100);
+        
+        write_allowance(&e, from, spender, amount, expiration_ledger);
+    }
+
+    fn balance(e: Env, id: Address) -> i128 {
+        e.storage().instance().extend_ttl(100, 100);
+        read_balance(&e, id)
+    }
+
+    fn transfer(e: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        e.storage().instance().extend_ttl(100, 100);
+        
+        spend_balance(&e, from, amount);
+        receive_balance(&e, to, amount);
+    }
+
+    fn transfer_from(e: Env, spender: Address, from: Address, to: Address, amount: i128) {
+        spender.require_auth();
+        e.storage().instance().extend_ttl(100, 100);
+        
+        spend_allowance(&e, from.clone(), spender, amount);
+        spend_balance(&e, from, amount);
+        receive_balance(&e, to, amount);
+    }
+
+    fn burn(e: Env, from: Address, amount: i128) {
+        from.require_auth();
+        e.storage().instance().extend_ttl(100, 100);
+        
+        spend_balance(&e, from, amount);
+    }
+
+    fn burn_from(e: Env, spender: Address, from: Address, amount: i128) {
+        spender.require_auth();
+        e.storage().instance().extend_ttl(100, 100);
+        
+        spend_allowance(&e, from.clone(), spender, amount);
+        spend_balance(&e, from, amount);
+    }
+
+    fn decimals(e: Env) -> u32 {
+        read_decimal(&e)
+    }
+
+    fn name(e: Env) -> String {
+        read_name(&e)
+    }
+
+    fn symbol(e: Env) -> String {
+        read_symbol(&e)
+    }
+}

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+mod admin;
+mod allowance;
+mod balance;
+mod contract;
+mod metadata;
+mod storage_types;
+
+#[cfg(test)]
+mod test;
+
+pub use crate::contract::TokenClient;
+pub use crate::contract::Token;

--- a/contracts/token/src/metadata.rs
+++ b/contracts/token/src/metadata.rs
@@ -1,0 +1,32 @@
+use soroban_sdk::{Env, String};
+use crate::storage_types::DataKey;
+
+pub fn read_decimal(e: &Env) -> u32 {
+    let key = DataKey::Decimals;
+    e.storage().instance().get(&key).unwrap()
+}
+
+pub fn write_decimal(e: &Env, d: u32) {
+    let key = DataKey::Decimals;
+    e.storage().instance().set(&key, &d);
+}
+
+pub fn read_name(e: &Env) -> String {
+    let key = DataKey::Name;
+    e.storage().instance().get(&key).unwrap()
+}
+
+pub fn write_name(e: &Env, name: &String) {
+    let key = DataKey::Name;
+    e.storage().instance().set(&key, name);
+}
+
+pub fn read_symbol(e: &Env) -> String {
+    let key = DataKey::Symbol;
+    e.storage().instance().get(&key).unwrap()
+}
+
+pub fn write_symbol(e: &Env, symbol: &String) {
+    let key = DataKey::Symbol;
+    e.storage().instance().set(&key, symbol);
+}

--- a/contracts/token/src/storage_types.rs
+++ b/contracts/token/src/storage_types.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::{contracttype, Address};
+
+#[derive(Clone)]
+#[contracttype]
+pub struct AllowanceDataKey {
+    pub from: Address,
+    pub spender: Address,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct AllowanceValue {
+    pub amount: i128,
+    pub expiration_ledger: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Allowance(AllowanceDataKey),
+    Balance(Address),
+    Admin,
+    State(Address), // User state (Deauthorized, etc - though standard token usually just has balance/allowance/admin/metadata)
+    // Metadata keys
+    Name,
+    Symbol,
+    Decimals,
+}

--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -1,0 +1,61 @@
+#![cfg(test)]
+
+use crate::contract::{Token, TokenClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_mint_and_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, Token);
+    let client = TokenClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    client.initialize(
+        &admin,
+        &7,
+        &String::from_str(&env, "Test Token"),
+        &String::from_str(&env, "TEST"),
+    );
+
+    client.mint(&user1, &1000);
+    assert_eq!(client.balance(&user1), 1000);
+
+    client.transfer(&user1, &user2, &200);
+    assert_eq!(client.balance(&user1), 800);
+    assert_eq!(client.balance(&user2), 200);
+}
+
+#[test]
+fn test_allowance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, Token);
+    let client = TokenClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    client.initialize(
+        &admin,
+        &7,
+        &String::from_str(&env, "Test Token"),
+        &String::from_str(&env, "TEST"),
+    );
+
+    client.mint(&user1, &1000);
+
+    client.approve(&user1, &spender, &500, &200);
+    assert_eq!(client.allowance(&user1, &spender), 500);
+
+    client.transfer_from(&spender, &user1, &spender, &200);
+    assert_eq!(client.balance(&user1), 800);
+    assert_eq!(client.balance(&spender), 200);
+    assert_eq!(client.allowance(&user1, &spender), 300);
+}

--- a/contracts/token/test_snapshots/test/test_allowance.1.json
+++ b/contracts/token/test_snapshots/test/test_allowance.1.json
@@ -1,0 +1,510 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "approve",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
+                },
+                {
+                  "u32": 200
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "transfer_from",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Allowance"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "from"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "spender"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Allowance"
+                    },
+                    {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "from"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "spender"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "durability": "temporary",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 300
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "expiration_ledger"
+                      },
+                      "val": {
+                        "u32": 200
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          15
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 800
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Decimals"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 7
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "Test Token"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "TEST"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/token/test_snapshots/test/test_mint_and_transfer.1.json
+++ b/contracts/token/test_snapshots/test/test_mint_and_transfer.1.json
@@ -1,0 +1,343 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 800
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Decimals"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 7
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Name"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "Test Token"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Symbol"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "string": "TEST"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-soroban-sdk = "22.0.0" # Adjust to the latest compatible version
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
 tokio = { version = "1", features = ["full"] }
 axum = "0.7"
 thiserror = "1.0"

--- a/core/src/benchmarks.rs
+++ b/core/src/benchmarks.rs
@@ -1,0 +1,75 @@
+use soroban_sdk::{testutils::Address as _, xdr::ScVal, Address, Bytes, Env, IntoVal, String, Symbol, Val, Vec};
+use std::fs;
+use std::path::PathBuf;
+
+pub fn run_token_benchmark(wasm_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Loading contract from: {:?}", wasm_path);
+    let wasm = fs::read(wasm_path)?;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Register contract
+    let wasm_bytes = Bytes::from_slice(&env, &wasm);
+    let contract_id = env.register_contract_wasm(None, wasm_bytes);
+    
+    // Initialize
+    let admin = Address::generate(&env);
+    let token_name = String::from_str(&env, "Benchmark Token");
+    let token_symbol = String::from_str(&env, "BNCH");
+    
+    println!("Invoking initialize...");
+    let args: Vec<Val> = Vec::from_array(&env, [admin.to_val(), 7u32.into_val(&env), token_name.to_val(), token_symbol.to_val()]);
+    let _res: Val = env.invoke_contract(
+        &contract_id, 
+        &Symbol::new(&env, "initialize"), 
+        args
+    );
+    
+    // Create users
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    // Mint
+    println!("Invoking mint...");
+    // Measure instructions before
+    env.cost_estimate().budget().reset_unlimited();
+    let start_cpu = env.cost_estimate().budget().cpu_instruction_cost();
+    let start_mem = env.cost_estimate().budget().memory_bytes_cost();
+
+    let args: Vec<Val> = Vec::from_array(&env, [user1.to_val(), 1000i128.into_val(&env)]);
+    let _res: Val = env.invoke_contract(
+        &contract_id,
+        &Symbol::new(&env, "mint"),
+        args
+    );
+
+    let end_cpu = env.cost_estimate().budget().cpu_instruction_cost();
+    let end_mem = env.cost_estimate().budget().memory_bytes_cost();
+
+    println!("Mint Stats:");
+    println!("  CPU Instructions: {}", end_cpu - start_cpu);
+    println!("  Memory Bytes: {}", end_mem - start_mem);
+
+    // Transfer
+    println!("Invoking transfer...");
+    env.cost_estimate().budget().reset_unlimited();
+    let start_cpu = env.cost_estimate().budget().cpu_instruction_cost();
+    let start_mem = env.cost_estimate().budget().memory_bytes_cost();
+
+    let args: Vec<Val> = Vec::from_array(&env, [user1.to_val(), user2.to_val(), 200i128.into_val(&env)]);
+    let _res: Val = env.invoke_contract(
+        &contract_id,
+        &Symbol::new(&env, "transfer"),
+        args
+    );
+
+    let end_cpu = env.cost_estimate().budget().cpu_instruction_cost();
+    let end_mem = env.cost_estimate().budget().memory_bytes_cost();
+
+    println!("Transfer Stats:");
+    println!("  CPU Instructions: {}", end_cpu - start_cpu);
+    println!("  Memory Bytes: {}", end_mem - start_mem);
+
+    Ok(())
+}

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,13 +1,49 @@
+mod benchmarks;
 mod errors;
 
 use crate::errors::AppError;
 use axum::{routing::get, Router};
+use std::env;
+use std::path::PathBuf;
 
 #[tokio::main]
 async fn main() {
+    // CLI Argument Handling
+    let args: Vec<String> = env::args().collect();
+    if args.len() > 1 && args[1] == "benchmark" {
+        println!("Starting SoroScope Benchmark...");
+        // Locate WASM - assuming running from workspace root or core
+        // Attempt to find it relative to current directory or know location
+        let possible_paths = vec![
+            "target/wasm32-unknown-unknown/release/soroban_token_contract.wasm",
+            "../target/wasm32-unknown-unknown/release/soroban_token_contract.wasm",
+        ];
+
+        let mut wasm_path = None;
+        for p in possible_paths {
+            let path = PathBuf::from(p);
+            if path.exists() {
+                wasm_path = Some(path);
+                break;
+            }
+        }
+
+        if let Some(path) = wasm_path {
+            if let Err(e) = benchmarks::run_token_benchmark(path) {
+                eprintln!("Benchmark failed: {}", e);
+            }
+        } else {
+            eprintln!("Could not find soroban_token_contract.wasm. Make sure to build the contract first.");
+        }
+        return;
+    }
+
+    // Default Web Server
+    println!("SoroScope CLI Initialized. Run with 'benchmark' argument to profile token contract.");
+    
     // build our application with a single route
     let app = Router::new()
-        .route("/", get(|| async { "Hello, World!" }))
+        .route("/", get(|| async { "Hello from SoroScope! Usage: cargo run -p soroscope-core -- benchmark" }))
         .route(
             "/error",
             get(|| async { Err::<&str, AppError>(AppError::BadRequest("Test error".to_string())) }),


### PR DESCRIPTION
I added the standard Soroban Token contract in contracts/token and updated the core CLI to include a benchmarking command that profiles the contract's resource usage.

You can now run the benchmark with: cargo run -p soroscope-core -- benchmark

closes #24 