### PR TITLE
Feat/lp volatility fee oracle

### DIFF
--- a/contracts/liquidity_pool/src/lib.rs
+++ b/contracts/liquidity_pool/src/lib.rs
@@ -22,6 +22,10 @@ pub enum Error {
     InvalidFee = 8,
     Paused = 9,
     InsufficientAllowance = 10,
+    OracleNotConfigured = 11,
+    InvalidOraclePrice = 12,
+    TimelockNotElapsed = 13,
+    NoPendingFeeUpdate = 14,
 }
 
 // Event structures for state-changing operations
@@ -87,6 +91,24 @@ pub struct FeeChangedEvent {
     pub new_fee_bps: i128,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeUpdateScheduledEvent {
+    pub scheduled_by: Address,
+    pub old_fee_bps: i128,
+    pub new_fee_bps: i128,
+    pub executable_after_ledger: u32,
+    pub volatility_bps: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingFeeUpdate {
+    pub new_fee_bps: i128,
+    pub executable_after_ledger: u32,
+    pub based_on_volatility_bps: i128,
+}
+
 // Helper function: integer square root using Newton's method
 fn sqrt(x: i128) -> i128 {
     if x == 0 {
@@ -132,8 +154,32 @@ pub enum DataKey {
     Allowance(AllowanceDataKey),
     Admin,
     FeeBasisPoints,
+    BaseFeeBasisPoints,
+    OracleAddress,
+    LastOraclePrice,
+    LastVolatilityBps,
+    FeeUpdateTimelockLedgers,
+    PendingFeeUpdate,
     Paused,
 }
+
+pub const MAX_FEE_BPS: i128 = 100;
+pub const DEFAULT_BASE_FEE_BPS: i128 = 30;
+pub const DEFAULT_FEE_TIMELOCK_LEDGERS: u32 = 120;
+
+pub const LOW_VOLATILITY_THRESHOLD_BPS: i128 = 100;
+pub const MEDIUM_VOLATILITY_THRESHOLD_BPS: i128 = 250;
+pub const HIGH_VOLATILITY_THRESHOLD_BPS: i128 = 500;
+
+pub const LOW_VOLATILITY_FEE_BPS: i128 = 40;
+pub const MEDIUM_VOLATILITY_FEE_BPS: i128 = 70;
+pub const HIGH_VOLATILITY_FEE_BPS: i128 = 100;
+
+pub trait PriceOracle {
+    fn latest_price(e: Env) -> i128;
+}
+
+soroban_sdk::contractclient!(name = "PriceOracleClient", trait = PriceOracle);
 
 fn check_paused(e: &Env) -> Result<(), Error> {
     let paused: bool = e
@@ -182,7 +228,13 @@ impl LiquidityPool {
         // Default fee: 30 bps (≈ 0.3%)
         e.storage()
             .instance()
-            .set(&DataKey::FeeBasisPoints, &30i128);
+            .set(&DataKey::FeeBasisPoints, &DEFAULT_BASE_FEE_BPS);
+        e.storage()
+            .instance()
+            .set(&DataKey::BaseFeeBasisPoints, &DEFAULT_BASE_FEE_BPS);
+        e.storage()
+            .instance()
+            .set(&DataKey::FeeUpdateTimelockLedgers, &DEFAULT_FEE_TIMELOCK_LEDGERS);
         Ok(())
     }
 
@@ -191,12 +243,12 @@ impl LiquidityPool {
         e.storage()
             .instance()
             .get(&DataKey::FeeBasisPoints)
-            .unwrap_or(30)
+            .unwrap_or(DEFAULT_BASE_FEE_BPS)
     }
 
     /// Admin-only: update the swap fee. Valid range: 0–100 bps (0%–1%).
     pub fn set_fee(e: Env, fee_bps: i128) -> Result<(), Error> {
-        if !(0..=100).contains(&fee_bps) {
+        if !(0..=MAX_FEE_BPS).contains(&fee_bps) {
             return Err(Error::InvalidFee);
         }
         let admin: Address = e
@@ -209,10 +261,13 @@ impl LiquidityPool {
             .storage()
             .instance()
             .get(&DataKey::FeeBasisPoints)
-            .unwrap_or(30);
+            .unwrap_or(DEFAULT_BASE_FEE_BPS);
         e.storage()
             .instance()
             .set(&DataKey::FeeBasisPoints, &fee_bps);
+        e.storage()
+            .instance()
+            .set(&DataKey::BaseFeeBasisPoints, &fee_bps);
         e.events().publish(
             (String::from_str(&e, "fee_changed"), admin.clone()),
             FeeChangedEvent {
@@ -222,6 +277,180 @@ impl LiquidityPool {
             },
         );
         Ok(())
+    }
+
+    /// Admin-only: configure external oracle and timelock parameters.
+    pub fn configure_fee_oracle(
+        e: Env,
+        oracle: Address,
+        base_fee_bps: i128,
+        timelock_ledgers: u32,
+    ) -> Result<(), Error> {
+        if !(0..=MAX_FEE_BPS).contains(&base_fee_bps) {
+            return Err(Error::InvalidFee);
+        }
+        let admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        e.storage().instance().set(&DataKey::OracleAddress, &oracle);
+        e.storage()
+            .instance()
+            .set(&DataKey::BaseFeeBasisPoints, &base_fee_bps);
+        e.storage()
+            .instance()
+            .set(&DataKey::FeeUpdateTimelockLedgers, &timelock_ledgers);
+
+        Ok(())
+    }
+
+    pub fn get_last_volatility_bps(e: Env) -> i128 {
+        e.storage()
+            .instance()
+            .get(&DataKey::LastVolatilityBps)
+            .unwrap_or(0)
+    }
+
+    pub fn get_pending_fee_update(e: Env) -> Option<PendingFeeUpdate> {
+        e.storage().instance().get(&DataKey::PendingFeeUpdate)
+    }
+
+    /// Pulls price from oracle, computes volatility and schedules a timelocked
+    /// fee update when the target fee differs from current fee.
+    pub fn sync_fee_from_oracle(e: Env) -> Result<Option<PendingFeeUpdate>, Error> {
+        let oracle: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::OracleAddress)
+            .ok_or(Error::OracleNotConfigured)?;
+
+        let oracle_client = PriceOracleClient::new(&e, &oracle);
+        let current_price = oracle_client.latest_price();
+        if current_price <= 0 {
+            return Err(Error::InvalidOraclePrice);
+        }
+
+        let previous_price: Option<i128> = e.storage().instance().get(&DataKey::LastOraclePrice);
+        e.storage()
+            .instance()
+            .set(&DataKey::LastOraclePrice, &current_price);
+
+        let prev = match previous_price {
+            Some(p) if p > 0 => p,
+            _ => {
+                e.storage().instance().set(&DataKey::LastVolatilityBps, &0i128);
+                return Ok(None);
+            }
+        };
+
+        let price_delta = if current_price >= prev {
+            current_price - prev
+        } else {
+            prev - current_price
+        };
+        let volatility_bps = price_delta
+            .checked_mul(10_000)
+            .ok_or(Error::InvalidOraclePrice)?
+            / prev;
+
+        e.storage()
+            .instance()
+            .set(&DataKey::LastVolatilityBps, &volatility_bps);
+
+        let base_fee_bps: i128 = e
+            .storage()
+            .instance()
+            .get(&DataKey::BaseFeeBasisPoints)
+            .unwrap_or(DEFAULT_BASE_FEE_BPS);
+        let target_fee = Self::target_fee_from_volatility(base_fee_bps, volatility_bps);
+        let current_fee = Self::get_fee(e.clone());
+        if target_fee == current_fee {
+            return Ok(None);
+        }
+
+        let timelock_ledgers: u32 = e
+            .storage()
+            .instance()
+            .get(&DataKey::FeeUpdateTimelockLedgers)
+            .unwrap_or(DEFAULT_FEE_TIMELOCK_LEDGERS);
+        let execute_after = e.ledger().sequence().saturating_add(timelock_ledgers);
+        let pending = PendingFeeUpdate {
+            new_fee_bps: target_fee,
+            executable_after_ledger: execute_after,
+            based_on_volatility_bps: volatility_bps,
+        };
+        e.storage().instance().set(&DataKey::PendingFeeUpdate, &pending);
+        let scheduled_by = e.current_contract_address();
+        e.events().publish(
+            (String::from_str(&e, "fee_update_scheduled"), scheduled_by.clone()),
+            FeeUpdateScheduledEvent {
+                scheduled_by,
+                old_fee_bps: current_fee,
+                new_fee_bps: target_fee,
+                executable_after_ledger: execute_after,
+                volatility_bps,
+            },
+        );
+
+        Ok(Some(pending))
+    }
+
+    /// Applies a previously scheduled fee update after timelock elapses.
+    pub fn execute_fee_update(e: Env) -> Result<i128, Error> {
+        let pending: PendingFeeUpdate = e
+            .storage()
+            .instance()
+            .get(&DataKey::PendingFeeUpdate)
+            .ok_or(Error::NoPendingFeeUpdate)?;
+
+        if e.ledger().sequence() < pending.executable_after_ledger {
+            return Err(Error::TimelockNotElapsed);
+        }
+        if !(0..=MAX_FEE_BPS).contains(&pending.new_fee_bps) {
+            return Err(Error::InvalidFee);
+        }
+
+        let admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        let old_fee = Self::get_fee(e.clone());
+        e.storage()
+            .instance()
+            .set(&DataKey::FeeBasisPoints, &pending.new_fee_bps);
+        e.storage().instance().remove(&DataKey::PendingFeeUpdate);
+
+        e.events().publish(
+            (String::from_str(&e, "fee_changed"), admin.clone()),
+            FeeChangedEvent {
+                admin,
+                old_fee_bps: old_fee,
+                new_fee_bps: pending.new_fee_bps,
+            },
+        );
+
+        Ok(pending.new_fee_bps)
+    }
+
+    fn target_fee_from_volatility(base_fee_bps: i128, volatility_bps: i128) -> i128 {
+        let dynamic_fee = if volatility_bps >= HIGH_VOLATILITY_THRESHOLD_BPS {
+            HIGH_VOLATILITY_FEE_BPS
+        } else if volatility_bps >= MEDIUM_VOLATILITY_THRESHOLD_BPS {
+            MEDIUM_VOLATILITY_FEE_BPS
+        } else if volatility_bps >= LOW_VOLATILITY_THRESHOLD_BPS {
+            LOW_VOLATILITY_FEE_BPS
+        } else {
+            base_fee_bps
+        };
+        if dynamic_fee > MAX_FEE_BPS {
+            MAX_FEE_BPS
+        } else {
+            dynamic_fee
+        }
     }
 
     /// Admin-only: pause or unpause the pool.

--- a/contracts/liquidity_pool/src/test.rs
+++ b/contracts/liquidity_pool/src/test.rs
@@ -1,12 +1,35 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
-    Address, Env, String as SorobanString, TryIntoVal,
+    contract, contractimpl, contracttype, Address, Env, String as SorobanString, TryIntoVal,
 };
 
 // Import Vec from alloc for no_std environment
 extern crate alloc;
 use alloc::vec::Vec;
+
+#[contract]
+struct MockOracle;
+
+#[contracttype]
+#[derive(Clone)]
+enum OracleDataKey {
+    Price,
+}
+
+#[contractimpl]
+impl MockOracle {
+    pub fn set_price(e: Env, price: i128) {
+        e.storage().instance().set(&OracleDataKey::Price, &price);
+    }
+
+    pub fn latest_price(e: Env) -> i128 {
+        e.storage()
+            .instance()
+            .get(&OracleDataKey::Price)
+            .unwrap_or(100_000_000i128)
+    }
+}
 
 #[test]
 fn test_basic_flow() {
@@ -944,6 +967,85 @@ fn test_set_fee_above_max() {
 
     // 101 bps — should panic with InvalidFee
     client.set_fee(&101);
+}
+
+#[test]
+fn test_oracle_fee_scheduling_and_timelock_execution() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register(LiquidityPool, ());
+    let client = LiquidityPoolClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    let token_a = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_b = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    client.initialize(&admin, &token_a, &token_b);
+
+    let oracle_id = e.register(MockOracle, ());
+    let oracle = MockOracleClient::new(&e, &oracle_id);
+    oracle.set_price(&100_000_000);
+
+    client.configure_fee_oracle(&oracle_id, &30, &5);
+
+    // First sync seeds the initial price and does not schedule.
+    let first_sync = client.sync_fee_from_oracle();
+    assert!(first_sync.is_none());
+
+    // 10% jump (1000 bps) should schedule high-volatility fee (100 bps).
+    oracle.set_price(&110_000_000);
+    let scheduled = client.sync_fee_from_oracle();
+    assert!(scheduled.is_some());
+    let pending = scheduled.unwrap();
+    assert_eq!(pending.new_fee_bps, 100);
+    assert_eq!(client.get_last_volatility_bps(), 1000);
+
+    // Not executable before timelock.
+    let early = client.try_execute_fee_update();
+    assert_eq!(early, Err(Ok(Error::TimelockNotElapsed)));
+
+    // Advance ledgers and execute.
+    let mut ledger_info = e.ledger().get();
+    ledger_info.sequence_number = pending.executable_after_ledger;
+    e.ledger().set(ledger_info);
+
+    let new_fee = client.execute_fee_update();
+    assert_eq!(new_fee, 100);
+    assert_eq!(client.get_fee(), 100);
+    assert!(client.get_pending_fee_update().is_none());
+}
+
+#[test]
+fn test_oracle_low_volatility_keeps_base_fee() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register(LiquidityPool, ());
+    let client = LiquidityPoolClient::new(&e, &contract_id);
+
+    let admin = Address::generate(&e);
+    let token_a = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_b = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    client.initialize(&admin, &token_a, &token_b);
+
+    let oracle_id = e.register(MockOracle, ());
+    let oracle = MockOracleClient::new(&e, &oracle_id);
+    oracle.set_price(&100_000_000);
+    client.configure_fee_oracle(&oracle_id, &30, &3);
+
+    assert!(client.sync_fee_from_oracle().is_none());
+    // 0.2% move => 20 bps, below low threshold.
+    oracle.set_price(&100_200_000);
+    assert!(client.sync_fee_from_oracle().is_none());
+    assert_eq!(client.get_fee(), 30);
 }
 
 #[test]

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -195,8 +195,34 @@ pub struct ResourceReport {
     pub cost_stroops: u64,
     /// Report showing which data was injected vs live
     pub state_dependency: Option<Vec<StateDependencyReport>>,
+    /// TTL status for touched ledger entries and extension suggestions.
+    pub ttl_analysis: Option<TtlAnalysisApiReport>,
     /// Efficiency score (0–100) and optimisation insights.
     pub nutrition: NutritionReport,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct TtlAnalysisApiReport {
+    pub current_ledger: u64,
+    pub touched_entries: Vec<TtlEntryApiReport>,
+    pub extend_ttl_suggestions: Vec<ExtendTtlSuggestionApi>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct TtlEntryApiReport {
+    pub key: String,
+    pub live_until_ledger: u32,
+    pub remaining_ledgers: i64,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct ExtendTtlSuggestionApi {
+    pub key: String,
+    pub current_live_until_ledger: u32,
+    pub remaining_ledgers: i64,
+    pub extend_to_ledger: u32,
+    pub ledgers_to_extend_by: u32,
+    pub suggested_operation: String,
 }
 
 /// "Nutrition label" for the contract invocation.
@@ -280,6 +306,30 @@ fn to_report(result: &SimulationResult, insights_engine: &InsightsEngine) -> Res
                     source: format!("{:?}", d.source),
                 })
                 .collect()
+        }),
+        ttl_analysis: result.ttl_analysis.as_ref().map(|ttl| TtlAnalysisApiReport {
+            current_ledger: ttl.current_ledger,
+            touched_entries: ttl
+                .touched_entries
+                .iter()
+                .map(|e| TtlEntryApiReport {
+                    key: e.key.clone(),
+                    live_until_ledger: e.live_until_ledger,
+                    remaining_ledgers: e.remaining_ledgers,
+                })
+                .collect(),
+            extend_ttl_suggestions: ttl
+                .extend_ttl_suggestions
+                .iter()
+                .map(|s| ExtendTtlSuggestionApi {
+                    key: s.key.clone(),
+                    current_live_until_ledger: s.current_live_until_ledger,
+                    remaining_ledgers: s.remaining_ledgers,
+                    extend_to_ledger: s.extend_to_ledger,
+                    ledgers_to_extend_by: s.ledgers_to_extend_by,
+                    suggested_operation: s.suggested_operation.clone(),
+                })
+                .collect(),
         }),
         nutrition: NutritionReport {
             efficiency_score: insights_report.efficiency_score,
@@ -441,6 +491,7 @@ async fn analyze_wasm(
         latest_ledger: 0,
         cost_stroops: 0,
         state_dependency: None,
+        ttl_analysis: None,
         transaction_data: String::new(),
     };
 
@@ -949,6 +1000,7 @@ mod tests {
             latest_ledger: 12345,
             cost_stroops: 5000,
             state_dependency: None,
+            ttl_analysis: None,
             transaction_data: "AAA".to_string(),
         };
 

--- a/core/src/simulation.rs
+++ b/core/src/simulation.rs
@@ -95,6 +95,8 @@ pub struct SimulationResult {
     pub cost_stroops: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state_dependency: Option<Vec<StateDependency>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl_analysis: Option<TtlAnalysisReport>,
     /// The SorobanTransactionData XDR returned by the RPC (base64)
     pub transaction_data: String,
 }
@@ -109,6 +111,30 @@ pub struct StateDependency {
 pub enum DataSource {
     Live,
     Injected,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TtlEntryReport {
+    pub key: String,
+    pub live_until_ledger: u32,
+    pub remaining_ledgers: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExtendTtlSuggestion {
+    pub key: String,
+    pub current_live_until_ledger: u32,
+    pub remaining_ledgers: i64,
+    pub extend_to_ledger: u32,
+    pub ledgers_to_extend_by: u32,
+    pub suggested_operation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TtlAnalysisReport {
+    pub current_ledger: u64,
+    pub touched_entries: Vec<TtlEntryReport>,
+    pub extend_ttl_suggestions: Vec<ExtendTtlSuggestion>,
 }
 
 #[derive(Debug, Serialize)]
@@ -150,7 +176,7 @@ struct RpcError {
     data: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct SimulationRpcResult {
     #[serde(default)]
@@ -171,6 +197,47 @@ struct ResourceCost {
     mem_bytes: String,
 }
 
+#[derive(Debug, Serialize)]
+struct GetLedgerEntriesRequest {
+    jsonrpc: String,
+    id: u64,
+    method: String,
+    params: GetLedgerEntriesParams,
+}
+
+#[derive(Debug, Serialize)]
+struct GetLedgerEntriesParams {
+    keys: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetLedgerEntriesResponse {
+    #[serde(flatten)]
+    result: LedgerEntriesResponseResult,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum LedgerEntriesResponseResult {
+    Success { result: GetLedgerEntriesResult },
+    Error { error: RpcError },
+}
+
+#[derive(Debug, Deserialize)]
+struct GetLedgerEntriesResult {
+    #[serde(default)]
+    entries: Vec<LedgerEntryWithMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LedgerEntryWithMeta {
+    key: String,
+    #[allow(dead_code)]
+    xdr: Option<String>,
+    live_until_ledger_seq: Option<u32>,
+}
+
 pub struct SimulationEngine {
     /// Kept for single-provider backward compatibility; empty when using registry.
     rpc_url: String,
@@ -181,6 +248,9 @@ pub struct SimulationEngine {
 }
 
 impl SimulationEngine {
+    const TTL_WARNING_THRESHOLD_LEDGERS: i64 = 120_000;
+    const TTL_TARGET_LEDGERS_AHEAD: i64 = 360_000;
+
     /// Create an engine backed by a single RPC URL (backward-compatible).
     #[allow(dead_code)]
     pub fn new(rpc_url: String) -> Self {
@@ -636,9 +706,180 @@ impl SimulationEngine {
             }
             ResponseResult::Success { result } => {
                 tracing::info!("Simulation successful at ledger {}", result.latest_ledger);
-                self.parse_simulation_result(result)
+                let mut parsed = self.parse_simulation_result(result.clone())?;
+                let touched_keys = self.extract_touched_ledger_keys(&result.transaction_data);
+
+                if !touched_keys.is_empty() {
+                    parsed.state_dependency = Some(
+                        touched_keys
+                            .iter()
+                            .map(|k| StateDependency {
+                                key: k.clone(),
+                                source: DataSource::Live,
+                            })
+                            .collect(),
+                    );
+
+                    match self
+                        .analyze_ttl_for_touched_entries(
+                            url,
+                            auth_header,
+                            auth_value,
+                            &touched_keys,
+                            result.latest_ledger,
+                        )
+                        .await
+                    {
+                        Ok(ttl_report) => {
+                            if !ttl_report.touched_entries.is_empty() {
+                                parsed.ttl_analysis = Some(ttl_report);
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("TTL analysis skipped due to RPC error: {}", e);
+                        }
+                    }
+                }
+
+                Ok(parsed)
             }
         }
+    }
+
+    fn extract_touched_ledger_keys(&self, transaction_data: &str) -> Vec<String> {
+        if transaction_data.is_empty() {
+            return Vec::new();
+        }
+
+        let xdr_bytes = match BASE64.decode(transaction_data) {
+            Ok(bytes) => bytes,
+            Err(_) => return Vec::new(),
+        };
+
+        let soroban_data = match SorobanTransactionData::from_xdr(&xdr_bytes, Limits::none()) {
+            Ok(data) => data,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut out = Vec::new();
+        let mut push_key = |key: &LedgerKey| {
+            if let Ok(bytes) = key.to_xdr(Limits::none()) {
+                out.push(BASE64.encode(bytes));
+            }
+        };
+
+        for key in soroban_data.resources.footprint.read_only.iter() {
+            push_key(key);
+        }
+        for key in soroban_data.resources.footprint.read_write.iter() {
+            push_key(key);
+        }
+
+        out.sort();
+        out.dedup();
+        out
+    }
+
+    async fn analyze_ttl_for_touched_entries(
+        &self,
+        url: &str,
+        auth_header: Option<&str>,
+        auth_value: Option<&str>,
+        touched_keys: &[String],
+        latest_ledger: u64,
+    ) -> Result<TtlAnalysisReport, SimulationError> {
+        let req = GetLedgerEntriesRequest {
+            jsonrpc: "2.0".to_string(),
+            id: 1,
+            method: "getLedgerEntries".to_string(),
+            params: GetLedgerEntriesParams {
+                keys: touched_keys.to_vec(),
+            },
+        };
+
+        let mut req_builder = self.client.post(url).json(&req);
+        if let (Some(header), Some(value)) = (auth_header, auth_value) {
+            req_builder = req_builder.header(header, value);
+        }
+
+        let response = tokio::time::timeout(self.request_timeout, req_builder.send())
+            .await
+            .map_err(|_| SimulationError::NodeTimeout)?
+            .map_err(|e| SimulationError::RpcRequestFailed(format!("Network error: {}", e)))?;
+
+        if !response.status().is_success() {
+            return Err(SimulationError::RpcRequestFailed(format!(
+                "HTTP error: {}",
+                response.status()
+            )));
+        }
+
+        let rpc_response: GetLedgerEntriesResponse = response.json().await.map_err(|e| {
+            SimulationError::RpcRequestFailed(format!("Failed to parse response: {}", e))
+        })?;
+
+        let entries = match rpc_response.result {
+            LedgerEntriesResponseResult::Success { result } => result.entries,
+            LedgerEntriesResponseResult::Error { error } => {
+                return Err(SimulationError::RpcRequestFailed(format!(
+                    "RPC error {}: {}",
+                    error.code, error.message
+                )))
+            }
+        };
+
+        let touched_entries: Vec<TtlEntryReport> = entries
+            .into_iter()
+            .filter_map(|entry| {
+                let live_until = entry.live_until_ledger_seq?;
+                let remaining = live_until as i64 - latest_ledger as i64;
+                Some(TtlEntryReport {
+                    key: entry.key,
+                    live_until_ledger: live_until,
+                    remaining_ledgers: remaining,
+                })
+            })
+            .collect();
+
+        let extend_ttl_suggestions =
+            Self::build_extend_ttl_suggestions(&touched_entries, latest_ledger);
+
+        Ok(TtlAnalysisReport {
+            current_ledger: latest_ledger,
+            touched_entries,
+            extend_ttl_suggestions,
+        })
+    }
+
+    fn build_extend_ttl_suggestions(
+        touched_entries: &[TtlEntryReport],
+        latest_ledger: u64,
+    ) -> Vec<ExtendTtlSuggestion> {
+        touched_entries
+            .iter()
+            .filter_map(|entry| {
+                if entry.remaining_ledgers > Self::TTL_WARNING_THRESHOLD_LEDGERS {
+                    return None;
+                }
+
+                let target = latest_ledger as i64 + Self::TTL_TARGET_LEDGERS_AHEAD;
+                let extend_to_ledger = target.max(entry.live_until_ledger as i64) as u32;
+                let ledgers_to_extend_by = extend_to_ledger.saturating_sub(entry.live_until_ledger);
+
+                Some(ExtendTtlSuggestion {
+                    key: entry.key.clone(),
+                    current_live_until_ledger: entry.live_until_ledger,
+                    remaining_ledgers: entry.remaining_ledgers,
+                    extend_to_ledger,
+                    ledgers_to_extend_by,
+                    suggested_operation: format!(
+                        "env.storage().persistent().extend_ttl(<key>, {}, {})",
+                        Self::TTL_WARNING_THRESHOLD_LEDGERS,
+                        Self::TTL_TARGET_LEDGERS_AHEAD
+                    ),
+                })
+            })
+            .collect()
     }
 
     fn parse_simulation_result(
@@ -675,6 +916,7 @@ impl SimulationEngine {
             latest_ledger: rpc_result.latest_ledger,
             cost_stroops,
             state_dependency: None,
+            ttl_analysis: None,
             transaction_data: rpc_result.transaction_data,
         })
     }
@@ -960,6 +1202,7 @@ impl SimulationEngine {
         let final_deps = state_dependency;
 
         result.state_dependency = Some(final_deps);
+        result.ttl_analysis = None;
 
         Ok(result)
     }
@@ -1375,6 +1618,7 @@ mod tests {
                 latest_ledger: 42,
                 cost_stroops: 10,
                 state_dependency: None,
+                ttl_analysis: None,
                 transaction_data: "AAA=".to_string(),
             }
         }
@@ -1465,5 +1709,26 @@ mod tests {
             assert_eq!(cache.get(&k1).await.unwrap().latest_ledger, 1);
             assert_eq!(cache.get(&k2).await.unwrap().latest_ledger, 2);
         }
+    }
+
+    #[test]
+    fn test_build_extend_ttl_suggestions_flags_low_ttl_entries() {
+        let entries = vec![
+            TtlEntryReport {
+                key: "key-a".to_string(),
+                live_until_ledger: 1_000,
+                remaining_ledgers: 500,
+            },
+            TtlEntryReport {
+                key: "key-b".to_string(),
+                live_until_ledger: 500_000,
+                remaining_ledgers: 200_000,
+            },
+        ];
+
+        let suggestions = SimulationEngine::build_extend_ttl_suggestions(&entries, 500);
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].key, "key-a");
+        assert!(suggestions[0].ledgers_to_extend_by > 0);
     }
 }


### PR DESCRIPTION
## Summary
This PR adds an oracle-driven dynamic fee module to the Liquidity Pool contract that increases swap fees during high volatility, with timelocked execution to preserve predictability and safety for LPs/traders.

- Integrates an external price oracle interface (`latest_price`) for on-chain price reads.
- Computes volatility from consecutive oracle prices in basis points.
- Maps volatility bands to protective fee tiers (capped at max fee).
- Schedules fee changes behind a ledger-based timelock.
- Requires explicit post-timelock execution to apply pending updates.

## Why
Static fees underprice risk during volatile markets and expose LPs to greater impermanent loss.  
This change lets fees adapt to market conditions while keeping updates transparent and non-instant via timelock.

## Changes

### `contracts/liquidity_pool/src/lib.rs`
- Added new error variants:
  - `OracleNotConfigured`
  - `InvalidOraclePrice`
  - `TimelockNotElapsed`
  - `NoPendingFeeUpdate`
- Added oracle integration:
  - `PriceOracle` trait + generated `PriceOracleClient`
  - `configure_fee_oracle(oracle, base_fee_bps, timelock_ledgers)` (admin-only)
- Added volatility + fee scheduling flow:
  - `sync_fee_from_oracle() -> Option<PendingFeeUpdate>`
  - Stores `LastOraclePrice` and `LastVolatilityBps`
  - Computes volatility as `abs(curr - prev) * 10_000 / prev`
  - Derives target fee from volatility thresholds
  - Schedules timelocked `PendingFeeUpdate`
- Added timelocked execution:
  - `execute_fee_update() -> i128`
  - Enforces `executable_after_ledger`
  - Applies fee and clears pending update
- Added new storage keys and constants for:
  - Base fee, oracle config, timelock settings, volatility tracking, pending update
  - Volatility thresholds and fee tiers
- Added event model for scheduling:
  - `FeeUpdateScheduledEvent`

### `contracts/liquidity_pool/src/test.rs`
- Added a mock oracle contract for deterministic tests.
- Added tests for:
  - High-volatility scheduling + timelock enforcement + successful execution.
  - Low-volatility behavior where base fee remains unchanged and no schedule is created.

## Fee Logic
- Low volatility (< 100 bps): keep `base_fee_bps`
- Medium (>= 100 bps): `40 bps`
- High (>= 250 bps): `70 bps`
- Very high (>= 500 bps): `100 bps` (capped)

## Security / Risk Notes
- Fee changes are not immediate; they must pass timelock.
- Invalid/missing oracle config and invalid prices are explicitly rejected.
- Max fee cap is enforced to prevent runaway fee values.
- `set_fee` still supports admin direct control and now updates base fee anchor.

## Test Plan
- Unit tests added in `contracts/liquidity_pool/src/test.rs` for oracle and timelock workflows.
- Run:
  - `cargo test -p liquidity_pool`
  
  closes #124