### PR TITLE
feat(proxy): add Soroban upgradeable proxy crate with admin-controlle…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
     "contracts/factory",
     "contracts/math",
     "contracts/typed_data_auth",
+    "contracts/proxy",
 ]

--- a/contracts/proxy/Cargo.toml
+++ b/contracts/proxy/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "proxy"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/proxy/src/lib.rs
+++ b/contracts/proxy/src/lib.rs
@@ -1,0 +1,12 @@
+#![no_std]
+
+mod proxy;
+mod proxy_logic;
+mod proxy_logic_v2;
+
+#[cfg(test)]
+mod test;
+
+pub use crate::proxy::{Proxy, ProxyClient};
+pub use crate::proxy_logic::{ProxyLogicV1, ProxyLogicV1Client};
+pub use crate::proxy_logic_v2::{ProxyLogicV2, ProxyLogicV2Client};

--- a/contracts/proxy/src/proxy.rs
+++ b/contracts/proxy/src/proxy.rs
@@ -1,0 +1,83 @@
+use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, IntoVal, Symbol, Val, Vec};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Implementation,
+    Counter,
+    Storage(BytesN<32>),
+}
+
+#[contract]
+pub struct Proxy;
+
+#[contractimpl]
+impl Proxy {
+    pub fn initialize(env: Env, admin: Address, implementation: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("Proxy already initialized");
+        }
+
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Implementation, &implementation);
+        env.storage().persistent().set(&DataKey::Counter, &0i32);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().persistent().get(&DataKey::Admin).unwrap()
+    }
+
+    pub fn get_implementation(env: Env) -> Address {
+        env.storage().persistent().get(&DataKey::Implementation).unwrap()
+    }
+
+    pub fn upgrade_to(env: Env, implementation: Address) {
+        let admin = Self::get_admin(env.clone());
+        env.require_auth(&admin);
+        env.storage().persistent().set(&DataKey::Implementation, &implementation);
+    }
+
+    pub fn upgrade_to_and_call(
+        env: Env,
+        implementation: Address,
+        method: Symbol,
+        args: Vec<Val>,
+    ) -> Val {
+        let admin = Self::get_admin(env.clone());
+        env.require_auth(&admin);
+        env.storage().persistent().set(&DataKey::Implementation, &implementation);
+        Self::delegate_call(env, method, args)
+    }
+
+    pub fn delegate_call(env: Env, method: Symbol, args: Vec<Val>) -> Val {
+        let implementation = Self::get_implementation(env.clone());
+        env.invoke_contract(&implementation, &method, args)
+    }
+
+    pub fn increment(env: Env, amount: i32) -> i32 {
+        let current = Self::get_value(env.clone());
+        let method = Symbol::new(&env, "calculate");
+        let args: Vec<Val> = Vec::from_array(&env, [current.into_val(&env), amount.into_val(&env)]);
+        let next: i32 = env.invoke_contract(&Self::get_implementation(env.clone()), &method, args);
+        Self::set_value(env, next);
+        next
+    }
+
+    pub fn get_value(env: Env) -> i32 {
+        env.storage().persistent().get(&DataKey::Counter).unwrap_or(0)
+    }
+
+    pub fn set_value(env: Env, value: i32) {
+        env.storage().persistent().set(&DataKey::Counter, &value);
+    }
+
+    pub fn set_storage(env: Env, key: BytesN<32>, value: Val) {
+        let admin = Self::get_admin(env.clone());
+        env.require_auth(&admin);
+        env.storage().persistent().set(&DataKey::Storage(key), &value);
+    }
+
+    pub fn get_storage(env: Env, key: BytesN<32>) -> Option<Val> {
+        env.storage().persistent().get(&DataKey::Storage(key))
+    }
+}

--- a/contracts/proxy/src/proxy_logic.rs
+++ b/contracts/proxy/src/proxy_logic.rs
@@ -1,0 +1,15 @@
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct ProxyLogicV1;
+
+#[contractimpl]
+impl ProxyLogicV1 {
+    pub fn calculate(_env: Env, a: i32, b: i32) -> i32 {
+        a + b
+    }
+
+    pub fn version(_env: Env) -> u32 {
+        1
+    }
+}

--- a/contracts/proxy/src/proxy_logic_v2.rs
+++ b/contracts/proxy/src/proxy_logic_v2.rs
@@ -1,0 +1,15 @@
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct ProxyLogicV2;
+
+#[contractimpl]
+impl ProxyLogicV2 {
+    pub fn calculate(_env: Env, a: i32, b: i32) -> i32 {
+        a + b + 10
+    }
+
+    pub fn version(_env: Env) -> u32 {
+        2
+    }
+}

--- a/contracts/proxy/src/test.rs
+++ b/contracts/proxy/src/test.rs
@@ -1,0 +1,60 @@
+#![cfg(test)]
+extern crate std;
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, IntoVal, Symbol, TryIntoVal, Val, Vec};
+
+#[test]
+fn test_proxy_upgrade_keeps_state_and_changes_logic() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let proxy_id = env.register(Proxy, ());
+    let impl_v1_id = env.register(ProxyLogicV1, ());
+    let impl_v2_id = env.register(ProxyLogicV2, ());
+
+    let proxy = ProxyClient::new(&env, &proxy_id);
+
+    proxy.initialize(&admin, &impl_v1_id);
+    assert_eq!(proxy.get_admin(), admin);
+    assert_eq!(proxy.get_implementation(), impl_v1_id);
+    assert_eq!(proxy.get_value(), 0);
+
+    let first = proxy.increment(&7);
+    assert_eq!(first, 7);
+    assert_eq!(proxy.get_value(), 7);
+
+    proxy.upgrade_to(&impl_v2_id);
+    assert_eq!(proxy.get_implementation(), impl_v2_id);
+
+    let second = proxy.increment(&3);
+    assert_eq!(second, 20);
+    assert_eq!(proxy.get_value(), 20);
+
+    let version_symbol = Symbol::new(&env, "version");
+    let version_val: Val = proxy.delegate_call(&version_symbol, Vec::new(&env));
+    let version: u32 = version_val.try_into_val(&env).unwrap();
+    assert_eq!(version, 2);
+}
+
+#[test]
+fn test_upgrade_to_and_call_executes_new_implementation_method() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let proxy_id = env.register(Proxy, ());
+    let impl_v2_id = env.register(ProxyLogicV2, ());
+
+    let proxy = ProxyClient::new(&env, &proxy_id);
+    proxy.initialize(&admin, &impl_v2_id);
+
+    let call_result: Val = proxy.upgrade_to_and_call(
+        &impl_v2_id,
+        Symbol::new(&env, "version"),
+        Vec::new(&env),
+    );
+    let version: u32 = call_result.try_into_val(&env).unwrap();
+    assert_eq!(version, 2);
+}


### PR DESCRIPTION
Close #136 

## PR Description

### Summary
Implemented a Soroban upgradable proxy pattern in a new proxy crate.

### What changed
- Added proxy workspace crate
- Implemented `Proxy` contract with:
  - admin-controlled initialization
  - persistent implementation address storage
  - strict `upgrade_to` access control
  - `upgrade_to_and_call` for atomic upgrade + call
  - `delegate_call` forwarding to current implementation
  - proxy-managed state storage to preserve contract state across upgrades
- Added two implementation contracts:
  - `ProxyLogicV1` with `calculate(a, b) = a + b`
  - `ProxyLogicV2` with `calculate(a, b) = a + b + 10`
- Added unit tests covering:
  - state preservation across upgrade
  - logic swap from V1 to V2
  - admin-controlled upgrade and delegate call behavior

### Testing
Run:
```bash
cargo test -p proxy
```
