### PR TITLE
feat(contracts): add oracle_aggregator sample contract with median ag…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
     "contracts/factory",
     "contracts/math",
     "contracts/typed_data_auth",
+    "contracts/oracle_aggregator",
 ]

--- a/contracts/oracle_aggregator/Cargo.toml
+++ b/contracts/oracle_aggregator/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "oracle-aggregator"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/oracle_aggregator/src/lib.rs
+++ b/contracts/oracle_aggregator/src/lib.rs
@@ -1,0 +1,109 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Vec};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotEnoughSources = 1,
+    NotEnoughValidPrices = 2,
+    NotEnoughReliableSources = 3,
+    InvalidPrice = 4,
+}
+
+pub trait PriceOracle {
+    fn latest_price(env: Env) -> Result<i128, Error>;
+}
+
+soroban_sdk::contractclient!(name = "PriceOracleClient", trait = PriceOracle);
+
+#[contract]
+pub struct OracleAggregator;
+
+#[contractimpl]
+impl OracleAggregator {
+    pub fn aggregate_price(env: Env, sources: Vec<Address>) -> Result<i128, Error> {
+        if sources.len() < 3 {
+            return Err(Error::NotEnoughSources);
+        }
+
+        let mut prices = Vec::new(&env);
+        for idx in 0..sources.len() {
+            let source = sources.get(idx).unwrap();
+            let client = PriceOracleClient::new(&env, &source);
+
+            if let Ok(price) = client.latest_price() {
+                if price > 0 {
+                    prices.push_back(price);
+                }
+            }
+        }
+
+        if prices.len() < 3 {
+            return Err(Error::NotEnoughValidPrices);
+        }
+
+        let mut sorted = Self::sort_prices(prices);
+        let median = Self::median(&sorted);
+        let filtered = Self::filter_outliers(&env, &sorted, median);
+
+        if filtered.len() < 3 {
+            return Err(Error::NotEnoughReliableSources);
+        }
+
+        Ok(Self::median(&filtered))
+    }
+
+    fn sort_prices(mut prices: Vec<i128>) -> Vec<i128> {
+        let n = prices.len();
+        for i in 0..n {
+            for j in 0..n - i - 1 {
+                let current = prices.get(j).unwrap();
+                let next = prices.get(j + 1).unwrap();
+                if current > next {
+                    prices.set(j, next);
+                    prices.set(j + 1, current);
+                }
+            }
+        }
+        prices
+    }
+
+    fn median(prices: &Vec<i128>) -> i128 {
+        let len = prices.len();
+        let mid = len / 2;
+        if len % 2 == 1 {
+            prices.get(mid).unwrap()
+        } else {
+            let low = prices.get(mid - 1).unwrap();
+            let high = prices.get(mid).unwrap();
+            (low + high) / 2
+        }
+    }
+
+    fn filter_outliers(env: &Env, prices: &Vec<i128>, median: i128) -> Vec<i128> {
+        let mut filtered = Vec::new(env);
+        let threshold = median.saturating_mul(5);
+
+        for idx in 0..prices.len() {
+            let price = prices.get(idx).unwrap();
+            if Self::abs_diff(price, median).saturating_mul(100) <= threshold {
+                filtered.push_back(price);
+            }
+        }
+
+        filtered
+    }
+
+    fn abs_diff(left: i128, right: i128) -> i128 {
+        if left > right {
+            left - right
+        } else {
+            right - left
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/oracle_aggregator/src/test.rs
+++ b/contracts/oracle_aggregator/src/test.rs
@@ -1,0 +1,118 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+#[contract]
+pub struct PriceSourceOk100;
+
+#[contractimpl]
+impl PriceSourceOk100 {
+    pub fn latest_price(_env: Env) -> Result<i128, Error> {
+        Ok(100)
+    }
+}
+
+#[contract]
+pub struct PriceSourceOk101;
+
+#[contractimpl]
+impl PriceSourceOk101 {
+    pub fn latest_price(_env: Env) -> Result<i128, Error> {
+        Ok(101)
+    }
+}
+
+#[contract]
+pub struct PriceSourceOk99;
+
+#[contractimpl]
+impl PriceSourceOk99 {
+    pub fn latest_price(_env: Env) -> Result<i128, Error> {
+        Ok(99)
+    }
+}
+
+#[contract]
+pub struct PriceSourceOutlier;
+
+#[contractimpl]
+impl PriceSourceOutlier {
+    pub fn latest_price(_env: Env) -> Result<i128, Error> {
+        Ok(150)
+    }
+}
+
+#[contract]
+pub struct PriceSourceUnresponsive;
+
+#[contractimpl]
+impl PriceSourceUnresponsive {
+    pub fn latest_price(_env: Env) -> Result<i128, Error> {
+        Err(Error::InvalidPrice)
+    }
+}
+
+fn register_sources(env: &Env) -> (Address, Address, Address, Address, Address) {
+    let ok_100 = env.register(PriceSourceOk100, ());
+    let ok_101 = env.register(PriceSourceOk101, ());
+    let ok_99 = env.register(PriceSourceOk99, ());
+    let outlier = env.register(PriceSourceOutlier, ());
+    let unresponsive = env.register(PriceSourceUnresponsive, ());
+    (ok_100, ok_101, ok_99, outlier, unresponsive)
+}
+
+#[test]
+fn test_aggregate_median_three_sources() {
+    let env = Env::default();
+    let (ok_100, ok_101, ok_99, _, _) = register_sources(&env);
+    let aggregator_id = env.register(OracleAggregator, ());
+    let client = OracleAggregatorClient::new(&env, &aggregator_id);
+    let sources = Vec::from_array(&env, [ok_100, ok_101, ok_99]);
+
+    assert_eq!(client.aggregate_price(&sources), Ok(100));
+}
+
+#[test]
+fn test_ignore_outlier_and_use_fallback() {
+    let env = Env::default();
+    let (ok_100, ok_101, ok_99, outlier, _) = register_sources(&env);
+    let aggregator_id = env.register(OracleAggregator, ());
+    let client = OracleAggregatorClient::new(&env, &aggregator_id);
+    let sources = Vec::from_array(&env, [ok_100, ok_101, ok_99, outlier]);
+
+    assert_eq!(client.aggregate_price(&sources), Ok(100));
+}
+
+#[test]
+fn test_skip_unresponsive_source() {
+    let env = Env::default();
+    let (ok_100, ok_101, ok_99, _, unresponsive) = register_sources(&env);
+    let aggregator_id = env.register(OracleAggregator, ());
+    let client = OracleAggregatorClient::new(&env, &aggregator_id);
+    let sources = Vec::from_array(&env, [ok_100, ok_101, ok_99, unresponsive]);
+
+    assert_eq!(client.aggregate_price(&sources), Ok(100));
+}
+
+#[test]
+fn test_reject_when_not_enough_sources() {
+    let env = Env::default();
+    let (ok_100, ok_101, _, _, _) = register_sources(&env);
+    let aggregator_id = env.register(OracleAggregator, ());
+    let client = OracleAggregatorClient::new(&env, &aggregator_id);
+    let sources = Vec::from_array(&env, [ok_100, ok_101]);
+
+    assert_eq!(client.aggregate_price(&sources), Err(Error::NotEnoughSources));
+}
+
+#[test]
+fn test_reject_when_not_enough_valid_prices() {
+    let env = Env::default();
+    let (ok_100, _, _, outlier, unresponsive) = register_sources(&env);
+    let aggregator_id = env.register(OracleAggregator, ());
+    let client = OracleAggregatorClient::new(&env, &aggregator_id);
+    let sources = Vec::from_array(&env, [ok_100, outlier, unresponsive]);
+
+    assert_eq!(client.aggregate_price(&sources), Err(Error::NotEnoughValidPrices));
+}


### PR DESCRIPTION
Close #134 

## PR Document

### Summary
Add a new Soroban sample contract `oracle_aggregator` that implements a multi-source price oracle aggregator using median calculation and outlier filtering. This contract provides fallback behavior for unresponsive or invalid sources and is now included in the workspace.

### What changed
- Added oracle_aggregator crate
- Implemented `OracleAggregator` contract:
  - accepts at least 3 price source addresses
  - queries each source via `PriceOracleClient`
  - collects valid positive prices
  - computes a median price
  - filters out prices deviating by more than 5% from the median
  - returns the aggregated median from reliable sources
- Added contract-level error handling:
  - `NotEnoughSources`
  - `NotEnoughValidPrices`
  - `NotEnoughReliableSources`
  - `InvalidPrice`
- Added unit tests covering:
  - median aggregation with 3 valid sources
  - outlier removal
  - handling an unresponsive source
  - insufficient source rejection
  - insufficient valid-price rejection
- Updated root Cargo.toml workspace members to include oracle_aggregator

### Files changed
- Cargo.toml
- Cargo.toml
- lib.rs
- test.rs

### Testing
Run:
```bash
cargo test -p oracle-aggregator
```

