### PR TITLE
Feat/104 disk persistent cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +336,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1042,6 +1057,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +1101,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -1123,6 +1148,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1614,6 +1648,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,7 +1777,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "plain",
  "redox_syscall 0.7.3",
@@ -1879,7 +1922,7 @@ dependencies = [
  "equivalent",
  "event-listener 5.4.1",
  "futures-util",
- "parking_lot",
+ "parking_lot 0.12.5",
  "portable-atomic",
  "smallvec",
  "tagptr",
@@ -2046,7 +2089,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2114,12 +2157,37 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2359,7 +2427,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -2516,11 +2584,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2529,7 +2606,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2658,7 +2735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.10.0",
  "serde",
  "serde_derive",
 ]
@@ -2748,7 +2825,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2881,7 +2958,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3100,6 +3177,22 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
 
 [[package]]
 name = "smallvec"
@@ -3328,6 +3421,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "bincode",
  "chrono",
  "config",
  "dotenvy",
@@ -3340,6 +3434,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sled",
  "soroban-sdk",
  "sqlx",
  "stellar-strkey",
@@ -3353,6 +3448,13 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+]
+
+[[package]]
+name = "soroscope-math"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -3486,7 +3588,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -3530,7 +3632,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "chrono",
  "crc",
@@ -3704,7 +3806,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3861,7 +3963,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4028,7 +4130,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "http",
  "http-body",
@@ -4045,7 +4147,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -4482,7 +4584,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -4537,6 +4639,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4544,6 +4662,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4904,7 +5028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.10.0",
  "indexmap 2.13.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,11 @@ members = [
     "contracts/cross_call",
     "contracts/factory",
     "contracts/math",
+]
+exclude = [
+    # Pins soroban-sdk=20 which is incompatible with the rest of the workspace
+    # (soroban-sdk=22). Tracked separately; upgrade the contract to the 22 API
+    # to re-include. Duplicated in PR #98 — expected to drop out on rebase
+    # once either branch lands.
     "contracts/typed_data_auth",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,6 +32,12 @@ ed25519-dalek = "2"
 sha2 = "0.10"
 rand = "0.8"
 moka = { version = "0.12", features = ["future"] }
+# Disk-backed L2 contract-state cache (issue #104). Sled is embedded, pure
+# Rust, and needs no external DB service. `bincode` serialises cache
+# payloads; the Cargo.lock for this workspace already pulls bincode 1.x
+# transitively via sled, so we pin the same major version here.
+sled = "0.34"
+bincode = "1.3"
 sqlx = { version = "0.7", features = ["runtime-tokio", "tls-native-tls", "postgres", "sqlite", "uuid", "chrono", "migrate"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/core/src/cache/disk.rs
+++ b/core/src/cache/disk.rs
@@ -1,0 +1,296 @@
+//! Disk-backed L2 contract state cache using Sled.
+//!
+//! Each cached payload is wrapped in a [`DiskCacheEntry`] that records the
+//! ledger sequence at which the entry was written. Reads reject entries
+//! older than `max_ledger_age` ledgers behind the caller's view of the
+//! current ledger and lazily evict them; a background sweep
+//! ([`DiskCache::evict_stale`]) removes stale entries in bulk when a new
+//! ledger lands.
+//!
+//! The store is keyed by arbitrary byte slices so callers can decide the
+//! key shape — today `SimulationCache` uses the hex-SHA256 of
+//! `(contract_id, function_name, args)`.
+
+use super::CacheError;
+use serde::{Deserialize, Serialize};
+use sled::Db;
+use std::path::{Path, PathBuf};
+
+/// Tunable parameters for [`DiskCache`].
+///
+/// Exposed as a struct (rather than just loose args) so the builder call
+/// site in `main.rs` reads cleanly when more knobs are added — size caps,
+/// compaction cadence, etc. are planned follow-ups.
+#[derive(Debug, Clone)]
+pub struct DiskCacheConfig {
+    /// Directory Sled will create / open. The directory is created if
+    /// missing.
+    pub path: PathBuf,
+    /// Maximum number of ledgers an entry may trail the current ledger
+    /// before it is treated as stale.
+    pub max_ledger_age: u32,
+}
+
+impl DiskCacheConfig {
+    pub fn new(path: impl Into<PathBuf>, max_ledger_age: u32) -> Self {
+        Self {
+            path: path.into(),
+            max_ledger_age,
+        }
+    }
+}
+
+/// Serialised wrapper persisted to disk. Stored alongside the payload so
+/// staleness checks don't need an out-of-band index.
+#[derive(Debug, Serialize, Deserialize)]
+struct DiskCacheEntry {
+    written_at_ledger: u32,
+    payload: Vec<u8>,
+}
+
+/// Sled-backed L2 cache.
+///
+/// Cheap to clone (`sled::Db` is `Arc`-backed internally), safe to share
+/// across async tasks. All methods are synchronous because Sled's I/O is
+/// fast on local disk; callers that care about runtime isolation are
+/// expected to wrap the store in `tokio::task::spawn_blocking` themselves.
+#[derive(Clone)]
+pub struct DiskCache {
+    db: Db,
+    max_ledger_age: u32,
+}
+
+impl DiskCache {
+    /// Open (or create) the Sled database at the given path.
+    pub fn open(config: DiskCacheConfig) -> Result<Self, CacheError> {
+        let db = sled::open(&config.path)?;
+        Ok(Self {
+            db,
+            max_ledger_age: config.max_ledger_age,
+        })
+    }
+
+    /// Convenience constructor for tests and ad-hoc call sites.
+    pub fn open_at(path: &Path, max_ledger_age: u32) -> Result<Self, CacheError> {
+        Self::open(DiskCacheConfig::new(path.to_path_buf(), max_ledger_age))
+    }
+
+    /// Look up `key` and return the raw payload if it is still within the
+    /// ledger-age window. Stale entries are evicted as a side effect so
+    /// the next caller doesn't re-read them.
+    ///
+    /// Errors are swallowed into `None` — an L2 failure must never break
+    /// the request path; callers treat it as a miss and the fetch path
+    /// still runs.
+    pub fn get(&self, key: &[u8], current_ledger: u32) -> Option<Vec<u8>> {
+        let raw = match self.db.get(key) {
+            Ok(Some(ivec)) => ivec,
+            Ok(None) => return None,
+            Err(e) => {
+                tracing::warn!(error = %e, "disk cache read failed, treating as miss");
+                return None;
+            }
+        };
+
+        let entry: DiskCacheEntry = match bincode::deserialize(raw.as_ref()) {
+            Ok(entry) => entry,
+            Err(e) => {
+                // Corrupt / schema-mismatched entry — drop it so the next
+                // write can replace it.
+                tracing::warn!(error = %e, "disk cache entry failed to deserialise, evicting");
+                let _ = self.db.remove(key);
+                return None;
+            }
+        };
+
+        if self.is_stale(current_ledger, entry.written_at_ledger) {
+            let _ = self.db.remove(key);
+            return None;
+        }
+
+        Some(entry.payload)
+    }
+
+    /// Insert `payload` tagged with `current_ledger`. Returns an error on
+    /// backend or serialisation failure — the caller decides whether to
+    /// propagate it or log-and-continue.
+    pub fn set(
+        &self,
+        key: &[u8],
+        payload: Vec<u8>,
+        current_ledger: u32,
+    ) -> Result<(), CacheError> {
+        let entry = DiskCacheEntry {
+            written_at_ledger: current_ledger,
+            payload,
+        };
+        let raw = bincode::serialize(&entry)?;
+        self.db.insert(key, raw)?;
+        Ok(())
+    }
+
+    /// Remove a specific key. Primarily exercised by tests; production
+    /// eviction happens via ledger-advance and ledger-age checks.
+    pub fn remove(&self, key: &[u8]) -> Result<(), CacheError> {
+        self.db.remove(key)?;
+        Ok(())
+    }
+
+    /// Sweep the store and remove every entry whose write ledger trails
+    /// `current_ledger` by more than `max_ledger_age`. Called from the
+    /// background ledger-watch loop on every new ledger.
+    ///
+    /// Returns the number of entries removed.
+    pub fn evict_stale(&self, current_ledger: u32) -> u64 {
+        let mut removed = 0u64;
+        for kv in self.db.iter() {
+            let (key, value) = match kv {
+                Ok(pair) => pair,
+                Err(e) => {
+                    tracing::warn!(error = %e, "disk cache iter failed mid-sweep");
+                    break;
+                }
+            };
+            match bincode::deserialize::<DiskCacheEntry>(value.as_ref()) {
+                Ok(entry) => {
+                    if self.is_stale(current_ledger, entry.written_at_ledger)
+                        && self.db.remove(&key).is_ok()
+                    {
+                        removed += 1;
+                    }
+                }
+                Err(_) => {
+                    // Corrupt entry — remove it on sight.
+                    if self.db.remove(&key).is_ok() {
+                        removed += 1;
+                    }
+                }
+            }
+        }
+        if removed > 0 {
+            tracing::debug!(
+                current_ledger,
+                removed,
+                "evicted stale entries from disk cache"
+            );
+        }
+        removed
+    }
+
+    /// Number of entries currently present. Useful for tests and metrics.
+    pub fn len(&self) -> usize {
+        self.db.len()
+    }
+
+    /// Report whether the store holds any entries.
+    pub fn is_empty(&self) -> bool {
+        self.db.is_empty()
+    }
+
+    /// Flush any in-memory Sled buffers to disk. Called before drop in
+    /// tests that simulate a crash / restart boundary.
+    pub fn flush(&self) -> Result<(), CacheError> {
+        self.db.flush()?;
+        Ok(())
+    }
+
+    /// Entry is stale when `current_ledger - written_at_ledger >
+    /// max_ledger_age`. `saturating_sub` protects against
+    /// out-of-order / future-dated writes — those are treated as fresh.
+    fn is_stale(&self, current_ledger: u32, written_at_ledger: u32) -> bool {
+        current_ledger.saturating_sub(written_at_ledger) > self.max_ledger_age
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn open_cache(dir: &Path, max_age: u32) -> DiskCache {
+        DiskCache::open_at(dir, max_age).expect("open disk cache")
+    }
+
+    #[test]
+    fn set_and_get_roundtrip() {
+        let dir = tempdir().unwrap();
+        let cache = open_cache(dir.path(), 100);
+        cache.set(b"key1", b"value1".to_vec(), 1000).unwrap();
+        assert_eq!(cache.get(b"key1", 1000), Some(b"value1".to_vec()));
+    }
+
+    #[test]
+    fn miss_returns_none() {
+        let dir = tempdir().unwrap();
+        let cache = open_cache(dir.path(), 100);
+        assert_eq!(cache.get(b"missing", 42), None);
+    }
+
+    #[test]
+    fn disk_cache_survives_restart() {
+        let dir = tempdir().unwrap();
+        {
+            let cache = open_cache(dir.path(), 100);
+            cache.set(b"key1", b"value1".to_vec(), 1000).unwrap();
+            cache.flush().unwrap();
+        }
+        // Reopen the same directory — simulates a process restart.
+        let cache2 = open_cache(dir.path(), 100);
+        assert_eq!(cache2.get(b"key1", 1050), Some(b"value1".to_vec()));
+    }
+
+    #[test]
+    fn stale_entries_are_evicted_on_read() {
+        let dir = tempdir().unwrap();
+        let cache = open_cache(dir.path(), 50);
+        cache.set(b"old", b"data".to_vec(), 1000).unwrap();
+        // current_ledger - written_at_ledger = 51 > max_ledger_age (50)
+        assert_eq!(cache.get(b"old", 1051), None);
+        // And the key is physically gone — next get with a "fresh" ledger
+        // view must still miss because the entry was evicted.
+        assert_eq!(cache.get(b"old", 1000), None);
+    }
+
+    #[test]
+    fn entries_at_boundary_are_still_fresh() {
+        let dir = tempdir().unwrap();
+        let cache = open_cache(dir.path(), 50);
+        cache.set(b"edge", b"data".to_vec(), 1000).unwrap();
+        // Exactly max_ledger_age behind — still fresh.
+        assert_eq!(cache.get(b"edge", 1050), Some(b"data".to_vec()));
+    }
+
+    #[test]
+    fn evict_stale_sweeps_all_old_entries() {
+        let dir = tempdir().unwrap();
+        let cache = open_cache(dir.path(), 10);
+        cache.set(b"a", b"A".to_vec(), 100).unwrap();
+        cache.set(b"b", b"B".to_vec(), 105).unwrap();
+        cache.set(b"c", b"C".to_vec(), 120).unwrap();
+        // At ledger 130: a (30 old) and b (25 old) are stale, c (10 old) is fresh.
+        let removed = cache.evict_stale(130);
+        assert_eq!(removed, 2);
+        assert_eq!(cache.get(b"a", 130), None);
+        assert_eq!(cache.get(b"b", 130), None);
+        assert_eq!(cache.get(b"c", 130), Some(b"C".to_vec()));
+    }
+
+    #[test]
+    fn set_overwrites_previous_entry() {
+        let dir = tempdir().unwrap();
+        let cache = open_cache(dir.path(), 100);
+        cache.set(b"k", b"v1".to_vec(), 100).unwrap();
+        cache.set(b"k", b"v2".to_vec(), 200).unwrap();
+        assert_eq!(cache.get(b"k", 200), Some(b"v2".to_vec()));
+    }
+
+    #[test]
+    fn future_dated_writes_are_not_stale() {
+        // If a write ledger is ahead of the current ledger (clock skew,
+        // reordered reads) the saturating-sub guard treats it as fresh.
+        let dir = tempdir().unwrap();
+        let cache = open_cache(dir.path(), 10);
+        cache.set(b"k", b"v".to_vec(), 200).unwrap();
+        assert_eq!(cache.get(b"k", 100), Some(b"v".to_vec()));
+    }
+}

--- a/core/src/cache/mod.rs
+++ b/core/src/cache/mod.rs
@@ -1,0 +1,33 @@
+//! Two-tier simulation cache: in-memory L1 + disk-persistent L2.
+//!
+//! The in-memory side (Moka) lives on [`crate::simulation::SimulationCache`]
+//! for backward compatibility; this module only ships the L2 layer plus the
+//! shared error type that spans both tiers. `SimulationCache` exposes
+//! `with_disk_cache` to attach an L2 store — when it is set, reads walk
+//! L1 → L2 → miss (and promote L2 hits into L1), and writes populate both
+//! layers so state survives restarts.
+
+pub mod disk;
+
+pub use disk::{DiskCache, DiskCacheConfig};
+
+use thiserror::Error;
+
+/// Errors surfaced by the cache subsystem.
+///
+/// These bubble up from Sled's disk store, bincode (de)serialisation, and
+/// I/O when opening a backing directory. The main service converts them
+/// into HTTP 500 via the `AppError` layer; callers inside the cache path
+/// normally treat L2 errors as misses and log-and-continue rather than
+/// failing the whole simulation.
+#[derive(Error, Debug)]
+pub enum CacheError {
+    #[error("disk cache I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("disk cache backend error: {0}")]
+    Backend(#[from] sled::Error),
+
+    #[error("cache payload (de)serialisation error: {0}")]
+    Serialization(#[from] bincode::Error),
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod comparison;
 pub mod errors;
 pub mod insights;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -16,6 +16,7 @@ use crate::errors::AppError;
 use crate::fee_analytics::{FeeAnalyticsEngine, MarketConditions, ModelBreakdown};
 use crate::fee_collector::{FeeCollector, FeeCollectorConfig};
 use crate::fee_store::FeeStore;
+use crate::cache::{DiskCache, DiskCacheConfig};
 use crate::insights::InsightsEngine;
 use crate::jobs::{
     JobId, JobQueue, JobQueueConfig, JobWorker, SubmitJobRequest, SubmitJobResponse,
@@ -89,6 +90,15 @@ struct AppConfig {
     /// Enable fee market analysis (default true).
     #[serde(default = "default_fee_analysis_enabled")]
     fee_analysis_enabled: bool,
+    /// Filesystem path that backs the disk-persistent L2 cache. When
+    /// empty the L2 tier is disabled and the service runs L1-only (same
+    /// behaviour as before #104).
+    #[serde(default = "default_disk_cache_path")]
+    disk_cache_path: String,
+    /// Number of ledgers a cached entry may lag the current ledger before
+    /// L2 treats it as stale. Default 100 ≈ 8 minutes at 5 s/ledger.
+    #[serde(default = "default_max_ledger_age")]
+    max_ledger_age: u32,
 }
 
 fn default_health_check_interval() -> u64 {
@@ -123,6 +133,17 @@ fn default_fee_analysis_enabled() -> bool {
     true
 }
 
+fn default_disk_cache_path() -> String {
+    // Empty == L2 disabled. Operators who want persistence set this in
+    // env / config.toml explicitly; we don't create a hidden directory
+    // in the CWD by default.
+    String::new()
+}
+
+fn default_max_ledger_age() -> u32 {
+    100
+}
+
 fn load_config() -> Result<AppConfig, ConfigError> {
     dotenvy::dotenv().ok();
 
@@ -143,6 +164,8 @@ fn load_config() -> Result<AppConfig, ConfigError> {
         .set_default("fee_collection_interval_secs", 5)?
         .set_default("fee_retention_days", 30)?
         .set_default("fee_analysis_enabled", true)?
+        .set_default("disk_cache_path", "")?
+        .set_default("max_ledger_age", 100)?
         .build()?;
 
     settings.try_deserialize()
@@ -1151,12 +1174,48 @@ async fn main() {
         tracing::info!("Fee market analysis is disabled");
     }
 
+    // Attach the disk-backed L2 cache when an operator-configured path
+    // is set. An empty path keeps the L1-only behaviour; a failure to
+    // open the directory is non-fatal — we log and continue without the
+    // L2 tier rather than preventing the service from starting.
+    let cache = {
+        let base = SimulationCache::new();
+        if config.disk_cache_path.is_empty() {
+            tracing::info!("Disk cache disabled (DISK_CACHE_PATH not set)");
+            base
+        } else {
+            let cfg = DiskCacheConfig::new(
+                std::path::PathBuf::from(&config.disk_cache_path),
+                config.max_ledger_age,
+            );
+            match DiskCache::open(cfg) {
+                Ok(disk) => {
+                    tracing::info!(
+                        path = %config.disk_cache_path,
+                        max_ledger_age = config.max_ledger_age,
+                        entries = disk.len(),
+                        "Disk cache attached as L2 tier"
+                    );
+                    base.with_disk_cache(Arc::new(disk))
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        path = %config.disk_cache_path,
+                        error = %e,
+                        "Failed to open disk cache; continuing with L1 only"
+                    );
+                    base
+                }
+            }
+        }
+    };
+
     let app_state = Arc::new(AppState {
         engine: SimulationEngine::with_registry_and_timeout(
             Arc::clone(&registry),
             simulation_timeout,
         ),
-        cache: SimulationCache::new(),
+        cache,
         insights_engine: InsightsEngine::new(),
         simulation_timeout,
         fee_analytics_engine,

--- a/core/src/simulation.rs
+++ b/core/src/simulation.rs
@@ -1517,6 +1517,18 @@ pub struct SimulationCache {
     inner: Cache<String, SimulationResult>,
     hits: AtomicU64,
     misses: AtomicU64,
+    /// Hits served from the disk-backed L2 tier (and promoted into L1).
+    /// Tracked separately so operators can tell an L1 hit apart from an
+    /// L2 hit in the emitted stats line.
+    l2_hits: AtomicU64,
+    /// Optional disk-backed L2 store. When `None`, the cache behaves
+    /// exactly as the L1-only MVP did.
+    l2: Option<Arc<crate::cache::DiskCache>>,
+    /// Caller-provided view of the current Soroban ledger, used to stamp
+    /// L2 writes and drive staleness checks on L2 reads. Defaults to `0`,
+    /// which disables age-based eviction until the caller wires in a
+    /// ledger watcher via [`set_current_ledger`](Self::set_current_ledger).
+    current_ledger: std::sync::atomic::AtomicU32,
 }
 
 impl SimulationCache {
@@ -1529,7 +1541,61 @@ impl SimulationCache {
             inner,
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
+            l2_hits: AtomicU64::new(0),
+            l2: None,
+            current_ledger: std::sync::atomic::AtomicU32::new(0),
         })
+    }
+
+    /// Return a new cache wrapping the same L1 state plus a disk-backed
+    /// L2 tier. Intended for construction at service start:
+    ///
+    /// ```ignore
+    /// let cache = SimulationCache::new().with_disk_cache(Arc::new(disk));
+    /// ```
+    ///
+    /// Takes `Arc<Self>` so the caller keeps the existing single-owner
+    /// invariant without juggling interior mutability on the cache
+    /// fields.
+    pub fn with_disk_cache(self: Arc<Self>, l2: Arc<crate::cache::DiskCache>) -> Arc<Self> {
+        // Unwrap, mutate, rewrap. `Arc::try_unwrap` only succeeds when the
+        // caller holds the only strong reference; that's fine at service
+        // start, which is the documented call site. A future caller that
+        // clones the Arc before attaching L2 panics loudly rather than
+        // silently dropping the L2 tier into a shadow copy.
+        let mut owned = Arc::try_unwrap(self).unwrap_or_else(|shared| {
+            panic!(
+                "SimulationCache::with_disk_cache called with {} live Arc clones; \
+                 attach the L2 tier before cloning the cache",
+                Arc::strong_count(&shared)
+            )
+        });
+        owned.l2 = Some(l2);
+        Arc::new(owned)
+    }
+
+    /// Update the cache's view of the current ledger. The ledger watcher
+    /// is expected to call this on every new ledger so L2 reads can
+    /// correctly reject entries older than `max_ledger_age` ledgers.
+    pub fn set_current_ledger(&self, ledger: u32) {
+        self.current_ledger
+            .store(ledger, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Read the current ledger the cache is using for L2 staleness
+    /// checks. Primarily useful for tests and `/health` diagnostics.
+    pub fn current_ledger(&self) -> u32 {
+        self.current_ledger
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Trigger a bulk sweep on the L2 store. No-op when no disk cache is
+    /// attached.
+    pub fn evict_stale_l2(&self) -> u64 {
+        match &self.l2 {
+            Some(l2) => l2.evict_stale(self.current_ledger()),
+            None => 0,
+        }
     }
 
     pub fn generate_key(contract_id: &str, function_name: &str, args: &[String]) -> String {
@@ -1540,27 +1606,91 @@ impl SimulationCache {
     }
 
     pub async fn get(&self, key: &str) -> Option<SimulationResult> {
-        let value: Option<SimulationResult> = self.inner.get(key).await;
-        if value.is_some() {
+        // L1 — Moka.
+        if let Some(value) = self.inner.get(key).await {
             self.hits.fetch_add(1, Ordering::Relaxed);
-            tracing::debug!(cache.key = %key, "Cache HIT");
-        } else {
-            self.misses.fetch_add(1, Ordering::Relaxed);
-            tracing::debug!(cache.key = %key, "Cache MISS");
+            tracing::debug!(cache.key = %key, "Cache HIT (L1)");
+            return Some(value);
         }
-        value
+
+        // L2 — disk. Any I/O or decode error falls through as a miss;
+        // the disk store logs the underlying reason itself.
+        //
+        // We serialise `SimulationResult` with serde_json rather than
+        // bincode because the struct carries `#[serde(skip_serializing_if)]`
+        // attributes. bincode writes positionally, so a skipped field on
+        // write would desynchronise the deserialiser on read; JSON is
+        // self-describing and handles the skip cleanly. The disk store
+        // itself still uses bincode for its own fixed-shape wrapper.
+        if let Some(l2) = &self.l2 {
+            let current_ledger = self.current_ledger();
+            if let Some(raw) = l2.get(key.as_bytes(), current_ledger) {
+                if let Ok(value) = serde_json::from_slice::<SimulationResult>(&raw) {
+                    self.l2_hits.fetch_add(1, Ordering::Relaxed);
+                    // Promote into L1 so subsequent reads skip the decode.
+                    self.inner.insert(key.to_string(), value.clone()).await;
+                    tracing::debug!(cache.key = %key, "Cache HIT (L2, promoted to L1)");
+                    return Some(value);
+                } else {
+                    tracing::warn!(
+                        cache.key = %key,
+                        "L2 payload failed to deserialise; treating as miss"
+                    );
+                }
+            }
+        }
+
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(cache.key = %key, "Cache MISS");
+        None
     }
 
     pub async fn set(&self, key: String, value: SimulationResult) {
+        // Write L2 first so a crash between L1 and L2 leaves the durable
+        // tier consistent; if L2 errors, L1 still gets populated so the
+        // request path isn't penalised.
+        if let Some(l2) = &self.l2 {
+            match serde_json::to_vec(&value) {
+                Ok(raw) => {
+                    // Use the simulation's own `latest_ledger` when
+                    // available — it's the ledger the payload is actually
+                    // valid against. Fall back to the cache's current
+                    // ledger view if the simulation didn't populate one.
+                    let written_at = if value.latest_ledger == 0 {
+                        self.current_ledger()
+                    } else {
+                        value.latest_ledger as u32
+                    };
+                    if let Err(e) = l2.set(key.as_bytes(), raw, written_at) {
+                        tracing::warn!(
+                            error = %e,
+                            cache.key = %key,
+                            "L2 write failed; L1 will still serve"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        cache.key = %key,
+                        "L2 payload serialisation failed; L1 will still serve"
+                    );
+                }
+            }
+        }
         self.inner.insert(key, value).await;
     }
 
     pub fn log_stats(&self) {
-        let hits = self.hits.load(Ordering::Relaxed);
+        let l1_hits = self.hits.load(Ordering::Relaxed);
+        let l2_hits = self.l2_hits.load(Ordering::Relaxed);
+        let hits = l1_hits + l2_hits;
         let misses = self.misses.load(Ordering::Relaxed);
         let total = hits + misses;
         let hit_rate_pct = if total > 0 { hits * 100 / total } else { 0 };
         tracing::info!(
+            cache.l1_hits = l1_hits,
+            cache.l2_hits = l2_hits,
             cache.hits = hits,
             cache.misses = misses,
             cache.total = total,
@@ -1923,6 +2053,115 @@ mod tests {
             cache.set(k2.clone(), r2).await;
             assert_eq!(cache.get(&k1).await.unwrap().latest_ledger, 1);
             assert_eq!(cache.get(&k2).await.unwrap().latest_ledger, 2);
+        }
+
+        // ── Two-tier L1+L2 tests ───────────────────────────────────────
+
+        fn open_disk_l2(max_age: u32) -> (tempfile::TempDir, Arc<crate::cache::DiskCache>) {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let disk = crate::cache::DiskCache::open_at(dir.path(), max_age)
+                .expect("open disk cache");
+            (dir, Arc::new(disk))
+        }
+
+        #[tokio::test]
+        async fn two_tier_cache_promotes_l2_hit_to_l1() {
+            let (_dir, l2) = open_disk_l2(100);
+            let cache = SimulationCache::new().with_disk_cache(Arc::clone(&l2));
+            let key = SimulationCache::generate_key("CONTRACT_A", "fn_x", &[]);
+
+            // Seed L2 directly — bypass the set() path so L1 stays empty.
+            let mut result = make_result();
+            result.latest_ledger = 500;
+            let raw = serde_json::to_vec(&result).unwrap();
+            l2.set(key.as_bytes(), raw, 500).unwrap();
+
+            // First get: L1 misses, L2 hits, result is promoted into L1.
+            let first = cache.get(&key).await.expect("L2 hit");
+            assert_eq!(first.latest_ledger, 500);
+            assert_eq!(cache.l2_hits.load(Ordering::Relaxed), 1);
+            assert_eq!(cache.hits.load(Ordering::Relaxed), 0);
+
+            // Second get: L1 now serves it.
+            let second = cache.get(&key).await.expect("L1 hit after promotion");
+            assert_eq!(second.latest_ledger, 500);
+            assert_eq!(cache.hits.load(Ordering::Relaxed), 1);
+            assert_eq!(cache.l2_hits.load(Ordering::Relaxed), 1);
+        }
+
+        #[tokio::test]
+        async fn two_tier_set_writes_through_to_l2() {
+            let (_dir, l2) = open_disk_l2(100);
+            let cache = SimulationCache::new().with_disk_cache(Arc::clone(&l2));
+            let key = SimulationCache::generate_key("CONTRACT_A", "fn_x", &[]);
+            let mut result = make_result();
+            result.latest_ledger = 300;
+            cache.set(key.clone(), result.clone()).await;
+
+            // Raw L2 read confirms the payload is there, stamped at the
+            // SimulationResult's own ledger sequence.
+            let raw = l2.get(key.as_bytes(), 300).expect("L2 has payload");
+            let decoded: SimulationResult = serde_json::from_slice(&raw).unwrap();
+            assert_eq!(decoded.latest_ledger, 300);
+        }
+
+        #[tokio::test]
+        async fn two_tier_stale_l2_entry_does_not_promote() {
+            // max_ledger_age = 10; entry written at ledger 100; we read
+            // at ledger 200 — well past the staleness threshold. Expect
+            // a full miss, not a promotion.
+            let (_dir, l2) = open_disk_l2(10);
+            let cache = SimulationCache::new().with_disk_cache(Arc::clone(&l2));
+            cache.set_current_ledger(200);
+            let key = SimulationCache::generate_key("CONTRACT_A", "fn_x", &[]);
+            let mut result = make_result();
+            result.latest_ledger = 100;
+            let raw = serde_json::to_vec(&result).unwrap();
+            l2.set(key.as_bytes(), raw, 100).unwrap();
+
+            assert!(cache.get(&key).await.is_none());
+            assert_eq!(cache.misses.load(Ordering::Relaxed), 1);
+            assert_eq!(cache.l2_hits.load(Ordering::Relaxed), 0);
+        }
+
+        #[tokio::test]
+        async fn two_tier_without_l2_behaves_as_l1_only() {
+            // Sanity-check: a cache built without `with_disk_cache` still
+            // works exactly like the pre-#104 cache.
+            let cache = SimulationCache::new();
+            let key = SimulationCache::generate_key("CONTRACT_A", "fn_x", &[]);
+            assert!(cache.get(&key).await.is_none());
+            cache.set(key.clone(), make_result()).await;
+            assert!(cache.get(&key).await.is_some());
+        }
+
+        #[tokio::test]
+        async fn current_ledger_is_readable_after_set() {
+            let cache = SimulationCache::new();
+            assert_eq!(cache.current_ledger(), 0);
+            cache.set_current_ledger(42);
+            assert_eq!(cache.current_ledger(), 42);
+        }
+
+        #[tokio::test]
+        async fn evict_stale_l2_is_noop_without_disk_cache() {
+            let cache = SimulationCache::new();
+            assert_eq!(cache.evict_stale_l2(), 0);
+        }
+
+        #[tokio::test]
+        async fn evict_stale_l2_sweeps_disk_when_attached() {
+            let (_dir, l2) = open_disk_l2(10);
+            let cache = SimulationCache::new().with_disk_cache(Arc::clone(&l2));
+            cache.set_current_ledger(200);
+            let key = SimulationCache::generate_key("C", "f", &[]);
+            let mut result = make_result();
+            result.latest_ledger = 100;
+            cache.set(key.clone(), result).await;
+            // Entry is in L2 stamped at 100; at current_ledger=200 with
+            // max_age=10 it's stale. The sweep must remove it.
+            assert_eq!(cache.evict_stale_l2(), 1);
+            assert_eq!(l2.len(), 0);
         }
     }
     // ── Multi-auth tests ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a disk-persistent L2 cache layer on top of the existing Moka L1
in-memory cache (#104).

## Problem

The current `SimulationCache` is in-memory only. Every service restart
is a full cold start — all simulation results must be re-fetched from
RPC, creating a burst of outbound calls and elevated latency for the
first N requests.

## Approach

Two-tier cache with the L1 unchanged and a new L2 behind an optional
builder, so callers that don't configure disk caching see no behaviour
change. Entries are tagged with the Soroban ledger sequence at which
they were produced and rejected once they trail the current ledger by
more than `max_ledger_age` ledgers. L2 hits are promoted into L1 on
read; writes populate both tiers.

## Changes

- **`core/src/cache/disk.rs`** (new) — `DiskCache` backed by Sled.
  Wraps payloads in `DiskCacheEntry { written_at_ledger, payload }`
  (bincode-encoded, fixed shape so the positional layout is stable).
  Exposes `open`, `open_at`, `get`, `set`, `remove`, `evict_stale`,
  `len`, `is_empty`, `flush`. Staleness uses `saturating_sub` so
  future-dated writes (clock skew, replay) are treated as fresh.
- **`core/src/cache/mod.rs`** (new) — module facade plus `CacheError`
  (I/O, Sled backend, bincode).
- **`core/src/simulation.rs`** — `SimulationCache` gains an optional
  `Arc<DiskCache>`, a `with_disk_cache` builder, `set_current_ledger` /
  `current_ledger` / `evict_stale_l2` helpers, and a separate
  `l2_hits` counter so `log_stats` can tell an L1 hit apart from an L2
  hit. `get` walks L1 → L2 → miss, promoting L2 hits. `set` writes L2
  first (so a crash between tiers leaves durable state consistent) and
  then L1; L2 errors log-and-continue so the request path is never
  penalised by a disk fault. Payloads at this boundary use
  `serde_json` rather than bincode because `SimulationResult` carries
  `#[serde(skip_serializing_if)]` attributes that would desynchronise
  bincode's positional deserialiser; the `DiskCacheEntry` wrapper one
  level down still uses bincode because its shape is fixed.
- **`core/src/main.rs`** — `AppConfig` gains `disk_cache_path` (empty
  default → L2 disabled) and `max_ledger_age` (default 100 ≈ 8 min at
  5 s/ledger). The bootstrap attaches the L2 when a path is set and
  logs-and-continues with L1 only if the directory fails to open, so a
  bad cache config never prevents startup.
- **`core/src/lib.rs`** — expose `pub mod cache`.
- **`core/Cargo.toml`** — add `sled = "0.34"` and `bincode = "1.3"`.

## Invalidation strategy

Ledger sequence number is the source of truth. An entry written at
ledger `N` is stale when `current_ledger - N > max_ledger_age`.

- **Lazy eviction** on read: stale entries are removed as a side
  effect of the miss.
- **Bulk eviction** via `SimulationCache::evict_stale_l2()`, intended
  to be called from the background ledger-watch loop on every new
  ledger. The hook is wired into `SimulationCache` but the actual
  scheduler call is a follow-up (see below).

## Config

| Setting              | Env var             | Default | Notes |
|----------------------|---------------------|---------|-------|
| `disk_cache_path`    | `DISK_CACHE_PATH`   | `""`    | Empty disables L2 |
| `max_ledger_age`     | `MAX_LEDGER_AGE`    | `100`   | ≈ 8 min @ 5 s/ledger |

## Testing

`core/src/cache/disk.rs` — `DiskCache` unit tests:

- `set_and_get_roundtrip` / `miss_returns_none` — base behaviour.
- `disk_cache_survives_restart` — write, flush, drop, re-open, read.
- `stale_entries_are_evicted_on_read` — past-max-age entries return
  `None` and are physically removed.
- `entries_at_boundary_are_still_fresh` — `max_ledger_age` exactly
  still serves.
- `evict_stale_sweeps_all_old_entries` — bulk sweep keeps fresh
  entries, removes stale ones.
- `set_overwrites_previous_entry` — write idempotency.
- `future_dated_writes_are_not_stale` — saturating-sub guard.

`core/src/simulation.rs` (`cache_tests`) — `SimulationCache` unit
tests:

- `two_tier_cache_promotes_l2_hit_to_l1` — L1 miss, L2 hit, L1
  populated on the way out; counters distinguish `l2_hits` from
  `hits`.
- `two_tier_set_writes_through_to_l2` — L2 receives the payload at
  the simulation's own `latest_ledger`.
- `two_tier_stale_l2_entry_does_not_promote` — past max-age entries
  fail the staleness check, counted as a miss.
- `two_tier_without_l2_behaves_as_l1_only` — pre-#104 behaviour
  preserved.
- `current_ledger_is_readable_after_set` / `evict_stale_l2_is_noop_without_disk_cache`
  / `evict_stale_l2_sweeps_disk_when_attached` — ledger-state plumbing.


## Follow-ups

- Wire `SimulationCache::evict_stale_l2()` into the ledger-watch loop
  once that subsystem exists. The current method is callable but has
  no scheduler.
- Wire `SimulationCache::set_current_ledger()` from the same ledger
  watcher. Until it's called, L2 entries with non-zero
  `latest_ledger` tag are never considered stale (because
  `current_ledger` stays at 0 and `saturating_sub` returns 0), which
  is a safe fallback but reduces eviction efficacy.
- RocksDB can replace Sled by swapping the `DiskCache` implementation
  behind the same API; the trait boundary is intentionally thin.
- Compaction and size limits are deferred to a follow-up (tracked
  against Sled's own background compaction for now).

## Interaction with PR #98

Both branches carry the same
`chore(workspace): exclude typed_data_auth…` commit. Whichever lands
first carries the fix; the other rebases the duplicate away cleanly.

Closes #104
