### PR TITLE
Feat/103 latency routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3356,6 +3356,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroscope-math"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,11 @@ members = [
     "contracts/cross_call",
     "contracts/factory",
     "contracts/math",
+]
+exclude = [
+    # Pins soroban-sdk=20 which is incompatible with the rest of the workspace
+    # (soroban-sdk=22). Tracked separately; upgrade the contract to the 22 API
+    # to re-include. Same fix as PRs #98 and #104 — whichever lands first
+    # carries the change, the others rebase cleanly.
     "contracts/typed_data_auth",
 ]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,5 +2,6 @@ pub mod comparison;
 pub mod errors;
 pub mod insights;
 pub mod parser;
+pub mod routing;
 pub mod rpc_provider;
 pub mod simulation;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -8,6 +8,7 @@ pub mod fee_store;
 pub mod insights;
 mod jobs;
 mod parser;
+mod routing;
 pub mod rpc_provider;
 mod simulation;
 

--- a/core/src/routing.rs
+++ b/core/src/routing.rs
@@ -1,0 +1,217 @@
+//! Pure routing algorithms for picking an RPC provider by measured RTT.
+//!
+//! The registry (`crate::rpc_provider`) owns the actual state — this
+//! module hosts the small algorithmic pieces (least-EMA selection,
+//! inverse-RTT weight computation) as free functions operating on
+//! caller-supplied slices, which makes them exhaustively testable
+//! without spinning up a full registry.
+//!
+//! The production dispatch path is
+//! [`crate::rpc_provider::ProviderRegistry::providers_by_latency`]; this
+//! module is the algorithmic core of that method plus extra helpers
+//! (weighted round-robin) that the registry may adopt later.
+
+use crate::rpc_provider::MIN_SAMPLES_FOR_EMA;
+
+/// View of one provider that the routing algorithms care about. All
+/// pure functions in this module take slices of `ProviderView`, which
+/// lets tests synthesise scenarios without any real RPC state.
+#[derive(Debug, Clone, Copy)]
+pub struct ProviderView<'a> {
+    pub name: &'a str,
+    pub is_healthy: bool,
+    pub ema_rtt_us: u64,
+    pub sample_count: u64,
+}
+
+/// Return the index (into `providers`) of the best provider to send the
+/// next request to, or `None` when no provider is healthy.
+///
+/// - Primary strategy: pick the healthy provider with the **lowest**
+///   EMA RTT. Requires every healthy provider to have reached
+///   [`MIN_SAMPLES_FOR_EMA`] samples so we don't bias against providers
+///   with short EMAs purely because they're new.
+/// - Fallback: while any healthy provider is below the threshold, use
+///   round-robin over the healthy set. `round_robin_cursor` is the
+///   caller's monotonically-advancing counter (typically an
+///   `AtomicUsize::fetch_add(1, …)` from the registry).
+pub fn select_provider_index(
+    providers: &[ProviderView<'_>],
+    round_robin_cursor: usize,
+) -> Option<usize> {
+    let healthy: Vec<(usize, ProviderView<'_>)> = providers
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.is_healthy)
+        .map(|(i, p)| (i, *p))
+        .collect();
+
+    if healthy.is_empty() {
+        return None;
+    }
+
+    let all_warmed = healthy
+        .iter()
+        .all(|(_, p)| p.sample_count >= MIN_SAMPLES_FOR_EMA);
+
+    if !all_warmed {
+        // Round-robin across the healthy subset. Modulo against
+        // `healthy.len()` (not `providers.len()`) so unhealthy
+        // providers are genuinely skipped rather than producing a
+        // no-op tick.
+        let pick = round_robin_cursor % healthy.len();
+        return Some(healthy[pick].0);
+    }
+
+    // Least-EMA. Ties break by original index — the first provider
+    // declared in config wins on equal latency.
+    healthy
+        .into_iter()
+        .min_by_key(|(i, p)| (p.ema_rtt_us, *i))
+        .map(|(i, _)| i)
+}
+
+/// Compute weighted round-robin weights for the healthy subset of
+/// `providers`. Returns one weight per healthy provider, in input order.
+/// Faster providers receive higher weights: `weight = max_rtt / rtt`.
+///
+/// Skips unhealthy providers entirely — the output length equals the
+/// count of healthy providers, so callers pairing the weights with
+/// indices must track the filter themselves.
+pub fn compute_inverse_rtt_weights(providers: &[ProviderView<'_>]) -> Vec<u64> {
+    let rtts: Vec<u64> = providers
+        .iter()
+        .filter(|p| p.is_healthy)
+        .map(|p| p.ema_rtt_us.max(1))
+        .collect();
+
+    if rtts.is_empty() {
+        return Vec::new();
+    }
+
+    let max_rtt = *rtts.iter().max().unwrap();
+    rtts.into_iter().map(|r| max_rtt / r).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper — build a healthy, fully-warmed provider view.
+    fn warm(name: &str, ema_us: u64) -> ProviderView<'_> {
+        ProviderView {
+            name,
+            is_healthy: true,
+            ema_rtt_us: ema_us,
+            sample_count: MIN_SAMPLES_FOR_EMA,
+        }
+    }
+
+    fn cold(name: &str) -> ProviderView<'_> {
+        ProviderView {
+            name,
+            is_healthy: true,
+            ema_rtt_us: 0,
+            sample_count: 0,
+        }
+    }
+
+    fn down(name: &str, ema_us: u64) -> ProviderView<'_> {
+        ProviderView {
+            name,
+            is_healthy: false,
+            ema_rtt_us: ema_us,
+            sample_count: MIN_SAMPLES_FOR_EMA,
+        }
+    }
+
+    #[test]
+    fn empty_pool_returns_none() {
+        assert_eq!(select_provider_index(&[], 0), None);
+    }
+
+    #[test]
+    fn all_unhealthy_returns_none() {
+        let pool = [down("a", 50), down("b", 100)];
+        assert_eq!(select_provider_index(&pool, 0), None);
+    }
+
+    #[test]
+    fn select_provider_picks_fastest_healthy() {
+        // slow at 500ms, fast at 50ms; fast must win on every cursor value.
+        let pool = [warm("slow", 500_000), warm("fast", 50_000)];
+        assert_eq!(select_provider_index(&pool, 0), Some(1));
+        assert_eq!(select_provider_index(&pool, 42), Some(1));
+    }
+
+    #[test]
+    fn select_provider_falls_back_to_round_robin_before_warmup() {
+        // `a` has no samples; we must use round-robin across both.
+        let pool = [cold("a"), warm("b", 50_000)];
+        assert_eq!(select_provider_index(&pool, 0), Some(0));
+        assert_eq!(select_provider_index(&pool, 1), Some(1));
+        assert_eq!(select_provider_index(&pool, 2), Some(0));
+    }
+
+    #[test]
+    fn round_robin_skips_unhealthy() {
+        // `a` and `c` healthy, `b` unhealthy; cursor should cycle a → c → a → …
+        let pool = [cold("a"), down("b", 100), cold("c")];
+        assert_eq!(select_provider_index(&pool, 0), Some(0));
+        assert_eq!(select_provider_index(&pool, 1), Some(2));
+        assert_eq!(select_provider_index(&pool, 2), Some(0));
+    }
+
+    #[test]
+    fn unhealthy_providers_are_excluded_from_ema_pick() {
+        // Fast but unhealthy — must not be picked. Slow but healthy
+        // is the only remaining candidate.
+        let pool = [down("fast", 10_000), warm("slow", 500_000)];
+        assert_eq!(select_provider_index(&pool, 0), Some(1));
+    }
+
+    #[test]
+    fn ties_broken_by_lowest_index() {
+        // Two providers, identical EMA — the first declared wins.
+        let pool = [warm("first", 100_000), warm("second", 100_000)];
+        assert_eq!(select_provider_index(&pool, 0), Some(0));
+    }
+
+    #[test]
+    fn inverse_rtt_weights_favour_faster_providers() {
+        // fast=50us, slow=500us → max/fast=10, max/slow=1
+        let pool = [warm("slow", 500), warm("fast", 50)];
+        assert_eq!(compute_inverse_rtt_weights(&pool), vec![1, 10]);
+    }
+
+    #[test]
+    fn inverse_rtt_weights_skip_unhealthy() {
+        let pool = [warm("a", 100), down("b", 10), warm("c", 50)];
+        assert_eq!(compute_inverse_rtt_weights(&pool), vec![1, 2]);
+    }
+
+    #[test]
+    fn inverse_rtt_weights_on_empty_healthy_pool_return_empty() {
+        let pool = [down("a", 100), down("b", 50)];
+        assert!(compute_inverse_rtt_weights(&pool).is_empty());
+    }
+
+    #[test]
+    fn zero_rtt_is_clamped_to_one_in_weight_calc() {
+        // A provider with an EMA of exactly zero (no samples) must not
+        // divide-by-zero the weight formula; it's clamped to 1us so it
+        // receives weight = max_rtt.
+        let pool = [
+            ProviderView {
+                name: "zero",
+                is_healthy: true,
+                ema_rtt_us: 0,
+                sample_count: MIN_SAMPLES_FOR_EMA,
+            },
+            warm("real", 200),
+        ];
+        let weights = compute_inverse_rtt_weights(&pool);
+        assert_eq!(weights.len(), 2);
+        assert!(weights[0] >= weights[1]);
+    }
+}

--- a/core/src/rpc_provider.rs
+++ b/core/src/rpc_provider.rs
@@ -1,6 +1,6 @@
 use reqwest::Client;
 use serde::Deserialize;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -15,6 +15,18 @@ const CIRCUIT_BREAKER_COOLDOWN: Duration = Duration::from_secs(5 * 60); // 5 min
 
 /// Timeout for the lightweight `getLatestLedger` health probe.
 const HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// EMA smoothing window, measured in samples. α = 2 / (window + 1) so a
+/// window of 20 weights the newest sample at ~9.5% — responsive enough
+/// to notice a provider slowing down within a few requests, stable
+/// enough that a single outlier doesn't dominate routing decisions.
+const DEFAULT_EMA_WINDOW: u32 = 20;
+
+/// Minimum samples a provider must have accumulated before its EMA is
+/// trusted for latency-based routing. Before every provider clears this
+/// threshold the registry falls back to round-robin so new providers
+/// are not starved of traffic they need to build up statistics.
+pub const MIN_SAMPLES_FOR_EMA: u64 = 10;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -33,6 +45,80 @@ pub struct RpcProvider {
     pub auth_value: Option<String>,
 }
 
+/// Per-provider latency statistics backed by lock-free atomics.
+///
+/// All values are microseconds, stored whole (not fixed-point) in an
+/// `AtomicU64`. The EMA update is a read-modify-write with
+/// `Ordering::Relaxed`: we do not need a total order across threads,
+/// only eventual convergence, and the alternative (mutex or CAS loop)
+/// would add contention on the request hot path for no measurable win.
+///
+/// The tiny race this allows — two threads racing to publish an EMA —
+/// costs at most one sample of noise on the published value and
+/// self-corrects on the next write.
+#[derive(Debug)]
+pub struct ProviderStats {
+    /// EMA of RTT in whole microseconds.
+    ema_rtt_us: AtomicU64,
+    /// Number of samples recorded since the registry started.
+    sample_count: AtomicU64,
+    /// α·10⁶ — the EMA smoothing factor scaled so the update loop is
+    /// integer-only. α = 2 / (window + 1).
+    alpha_millionths: u64,
+}
+
+impl ProviderStats {
+    /// Build a fresh stats tracker with `ema_window` samples of memory.
+    /// Smaller windows react faster to latency changes; larger windows
+    /// smooth over transient outliers.
+    pub fn new(ema_window: u32) -> Self {
+        // Guard against a zero window (would divide by zero / make the
+        // EMA always-latest). Clamp to at least 1 sample of history.
+        let w = ema_window.max(1) as u64;
+        let alpha_millionths = 2_000_000 / (w + 1);
+        Self {
+            ema_rtt_us: AtomicU64::new(0),
+            sample_count: AtomicU64::new(0),
+            alpha_millionths,
+        }
+    }
+
+    /// Record one RTT observation (microseconds) and fold it into the
+    /// EMA. The first sample seeds the EMA directly so the series
+    /// starts on the true value rather than slowly rising from zero.
+    pub fn record(&self, rtt_us: u64) {
+        let count = self.sample_count.fetch_add(1, Ordering::Relaxed);
+        if count == 0 {
+            self.ema_rtt_us.store(rtt_us, Ordering::Relaxed);
+            return;
+        }
+        let prev = self.ema_rtt_us.load(Ordering::Relaxed);
+        let alpha = self.alpha_millionths;
+        // EMA = α·sample + (1−α)·prev, all scaled by 10⁶ then divided
+        // back down at the end.
+        let new_ema = (alpha * rtt_us + (1_000_000 - alpha) * prev) / 1_000_000;
+        self.ema_rtt_us.store(new_ema, Ordering::Relaxed);
+    }
+
+    /// Current EMA in microseconds. Zero means no samples have been
+    /// recorded yet.
+    pub fn ema_rtt_us(&self) -> u64 {
+        self.ema_rtt_us.load(Ordering::Relaxed)
+    }
+
+    /// Total samples recorded so far. Used to gate the switch from
+    /// warmup (round-robin) to steady-state (least-EMA) routing.
+    pub fn sample_count(&self) -> u64 {
+        self.sample_count.load(Ordering::Relaxed)
+    }
+
+    /// True once the stats have enough samples to drive latency-based
+    /// routing decisions. See [`MIN_SAMPLES_FOR_EMA`].
+    pub fn is_warmed(&self) -> bool {
+        self.sample_count() >= MIN_SAMPLES_FOR_EMA
+    }
+}
+
 /// Runtime health state for a single provider.
 #[derive(Debug)]
 struct ProviderState {
@@ -43,12 +129,31 @@ struct ProviderState {
     tripped_at: RwLock<Option<Instant>>,
     /// Latest ledger number returned by the last successful health check.
     latest_ledger: AtomicU64,
+    /// RTT statistics recorded by every successful request against this
+    /// provider (see [`ProviderRegistry::record_rtt`]).
+    stats: ProviderStats,
+}
+
+/// Immutable snapshot of one provider's identity and current RTT
+/// statistics. Returned by [`ProviderRegistry::stats_snapshot`] so
+/// callers (metrics exporters, `/health`, tests) can inspect latency
+/// data without holding any registry lock.
+#[derive(Debug, Clone)]
+pub struct ProviderStatsSnapshot {
+    pub name: String,
+    pub url: String,
+    pub ema_rtt_us: u64,
+    pub sample_count: u64,
 }
 
 /// Thread-safe registry that tracks provider health and drives failover.
 pub struct ProviderRegistry {
     states: Vec<Arc<ProviderState>>,
     client: Client,
+    /// Rotating cursor used by the round-robin fallback path during the
+    /// warmup window, before every provider has produced the minimum
+    /// number of RTT samples required to trust its EMA.
+    round_robin_cursor: AtomicUsize,
 }
 
 impl ProviderRegistry {
@@ -64,6 +169,7 @@ impl ProviderRegistry {
                     consecutive_failures: AtomicU64::new(0),
                     tripped_at: RwLock::new(None),
                     latest_ledger: AtomicU64::new(0),
+                    stats: ProviderStats::new(DEFAULT_EMA_WINDOW),
                 })
             })
             .collect();
@@ -71,6 +177,7 @@ impl ProviderRegistry {
         Arc::new(Self {
             states,
             client: Client::new(),
+            round_robin_cursor: AtomicUsize::new(0),
         })
     }
 
@@ -84,6 +191,78 @@ impl ProviderRegistry {
             }
         }
         available
+    }
+
+    /// Return the list of healthy providers ordered by preference for the
+    /// failover loop, honouring measured latency when available:
+    ///
+    /// - If **every** healthy provider has reached [`MIN_SAMPLES_FOR_EMA`]
+    ///   samples, sort by EMA ascending — the fastest observed provider
+    ///   is tried first.
+    /// - Otherwise fall back to round-robin (starting index advances by
+    ///   one on each call) to give new providers a chance to accumulate
+    ///   statistics instead of being starved by warmer neighbours.
+    ///
+    /// The callers' existing fallback-on-error behaviour is preserved:
+    /// this method only changes **ordering**. Even the slowest healthy
+    /// provider remains in the returned list so the simulation engine
+    /// can still fail over to it if the top pick errors.
+    pub async fn providers_by_latency(&self) -> Vec<&RpcProvider> {
+        let mut available: Vec<&Arc<ProviderState>> = Vec::new();
+        for state in &self.states {
+            if self.is_available(state).await {
+                available.push(state);
+            }
+        }
+        if available.is_empty() {
+            return Vec::new();
+        }
+
+        let all_warmed = available.iter().all(|s| s.stats.is_warmed());
+
+        if all_warmed {
+            available.sort_by_key(|s| s.stats.ema_rtt_us());
+        } else {
+            // Round-robin bootstrap. We don't shuffle — we rotate by one
+            // position per call so the cursor advances deterministically
+            // and every provider gets its turn as the "first" pick.
+            let cursor = self.round_robin_cursor.fetch_add(1, Ordering::Relaxed);
+            available.rotate_left(cursor % available.len());
+        }
+
+        available.into_iter().map(|s| &s.provider).collect()
+    }
+
+    /// Record an RTT observation (microseconds) for the provider at
+    /// `url`. No-op when the URL is unknown so the caller can record
+    /// unconditionally without paying a lookup cost on a miss.
+    pub fn record_rtt(&self, url: &str, rtt_us: u64) {
+        if let Some(state) = self.find_by_url(url) {
+            state.stats.record(rtt_us);
+            tracing::debug!(
+                provider = %state.provider.name,
+                rtt_us,
+                ema_rtt_us = state.stats.ema_rtt_us(),
+                samples = state.stats.sample_count(),
+                "RTT sample recorded"
+            );
+        }
+    }
+
+    /// Snapshot the current RTT statistics for every provider in the
+    /// registry. Intended for metrics endpoints, `/health`, and tests —
+    /// the returned `Vec` is a value type so callers don't hold any
+    /// registry lock across inspection.
+    pub fn stats_snapshot(&self) -> Vec<ProviderStatsSnapshot> {
+        self.states
+            .iter()
+            .map(|s| ProviderStatsSnapshot {
+                name: s.provider.name.clone(),
+                url: s.provider.url.clone(),
+                ema_rtt_us: s.stats.ema_rtt_us(),
+                sample_count: s.stats.sample_count(),
+            })
+            .collect()
     }
 
     /// Report a successful request to `url`. Resets the failure counter and
@@ -356,5 +535,157 @@ mod tests {
         assert_eq!(healthy[0].name, "primary");
         assert_eq!(healthy[1].name, "secondary");
         assert_eq!(healthy[2].name, "tertiary");
+    }
+
+    // ── ProviderStats / latency routing tests ─────────────────────────────
+
+    /// Helper: record `count` identical samples to warm the EMA past the
+    /// routing threshold and onto a stable value.
+    fn warm_stats(stats: &ProviderStats, rtt_us: u64, count: u64) {
+        for _ in 0..count {
+            stats.record(rtt_us);
+        }
+    }
+
+    #[test]
+    fn ema_converges_toward_true_value() {
+        let stats = ProviderStats::new(20);
+        warm_stats(&stats, 1000, 100);
+        // With α ≈ 0.095 and 100 identical samples, the EMA sits right
+        // on the true value — anything further than 5% off would be a
+        // real bug.
+        let ema = stats.ema_rtt_us();
+        let drift = ema.abs_diff(1000);
+        assert!(drift <= 50, "EMA drifted {drift}µs from 1000µs");
+        assert_eq!(stats.sample_count(), 100);
+    }
+
+    #[test]
+    fn ema_first_sample_seeds_exact_value() {
+        // The series starts at the first sample instead of climbing from
+        // zero — otherwise early routing decisions would penalise brand
+        // new providers.
+        let stats = ProviderStats::new(20);
+        stats.record(777);
+        assert_eq!(stats.ema_rtt_us(), 777);
+    }
+
+    #[test]
+    fn ema_zero_window_is_clamped_safely() {
+        // A caller-supplied zero window would have divided by zero; the
+        // constructor clamps it to a 1-sample minimum.
+        let stats = ProviderStats::new(0);
+        stats.record(500);
+        stats.record(1000);
+        // Just ensure no panic and the EMA moved.
+        assert!(stats.ema_rtt_us() > 0);
+        assert_eq!(stats.sample_count(), 2);
+    }
+
+    #[test]
+    fn is_warmed_reflects_sample_count_threshold() {
+        let stats = ProviderStats::new(20);
+        assert!(!stats.is_warmed());
+        for _ in 0..MIN_SAMPLES_FOR_EMA - 1 {
+            stats.record(100);
+        }
+        assert!(!stats.is_warmed(), "{} samples is below threshold", stats.sample_count());
+        stats.record(100);
+        assert!(stats.is_warmed(), "{} samples should be warmed", stats.sample_count());
+    }
+
+    #[tokio::test]
+    async fn providers_by_latency_picks_fastest_once_warm() {
+        let registry = ProviderRegistry::new(vec![
+            make_provider("slow", "http://slow.test"),
+            make_provider("fast", "http://fast.test"),
+        ]);
+        // Warm both with very different latencies.
+        for _ in 0..MIN_SAMPLES_FOR_EMA {
+            registry.record_rtt("http://slow.test", 500_000);
+            registry.record_rtt("http://fast.test", 50_000);
+        }
+        let ordered = registry.providers_by_latency().await;
+        assert_eq!(ordered.len(), 2);
+        assert_eq!(ordered[0].name, "fast");
+        assert_eq!(ordered[1].name, "slow");
+    }
+
+    #[tokio::test]
+    async fn providers_by_latency_round_robins_before_warmup() {
+        let registry = ProviderRegistry::new(vec![
+            make_provider("a", "http://a.test"),
+            make_provider("b", "http://b.test"),
+        ]);
+        // Neither provider has any samples → round-robin fallback.
+        let first = registry.providers_by_latency().await;
+        let second = registry.providers_by_latency().await;
+        assert_eq!(first.len(), 2);
+        assert_eq!(second.len(), 2);
+        // The cursor rotates by one each call, so the head differs.
+        assert_ne!(first[0].name, second[0].name);
+    }
+
+    #[tokio::test]
+    async fn providers_by_latency_excludes_unhealthy_providers() {
+        let registry = ProviderRegistry::new(vec![
+            make_provider("fast-but-down", "http://fast-down.test"),
+            make_provider("slow-but-up", "http://slow-up.test"),
+        ]);
+        // Fast provider has the best EMA but we trip its breaker.
+        for _ in 0..MIN_SAMPLES_FOR_EMA {
+            registry.record_rtt("http://fast-down.test", 10_000);
+            registry.record_rtt("http://slow-up.test", 500_000);
+        }
+        for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+            registry.report_failure("http://fast-down.test").await;
+        }
+        let ordered = registry.providers_by_latency().await;
+        assert_eq!(ordered.len(), 1);
+        assert_eq!(ordered[0].name, "slow-but-up");
+    }
+
+    #[tokio::test]
+    async fn providers_by_latency_empty_when_all_unhealthy() {
+        let registry = ProviderRegistry::new(vec![
+            make_provider("a", "http://a.test"),
+            make_provider("b", "http://b.test"),
+        ]);
+        for _ in 0..CIRCUIT_BREAKER_THRESHOLD {
+            registry.report_failure("http://a.test").await;
+            registry.report_failure("http://b.test").await;
+        }
+        assert!(registry.providers_by_latency().await.is_empty());
+    }
+
+    #[test]
+    fn record_rtt_for_unknown_url_is_noop() {
+        // No panic, no sample recorded.
+        let registry = ProviderRegistry::new(vec![make_provider("a", "http://a.test")]);
+        registry.record_rtt("http://unknown.test", 100);
+        let snap = registry.stats_snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].sample_count, 0);
+    }
+
+    #[test]
+    fn stats_snapshot_reflects_recorded_samples() {
+        let registry = ProviderRegistry::new(vec![
+            make_provider("a", "http://a.test"),
+            make_provider("b", "http://b.test"),
+        ]);
+        for _ in 0..5 {
+            registry.record_rtt("http://a.test", 1_000);
+        }
+        registry.record_rtt("http://b.test", 10_000);
+
+        let snap = registry.stats_snapshot();
+        let a = snap.iter().find(|s| s.name == "a").unwrap();
+        let b = snap.iter().find(|s| s.name == "b").unwrap();
+        assert_eq!(a.sample_count, 5);
+        assert_eq!(b.sample_count, 1);
+        // EMA for `a` converged to 1_000; `b` seeded at 10_000.
+        assert_eq!(a.ema_rtt_us, 1_000);
+        assert_eq!(b.ema_rtt_us, 10_000);
     }
 }

--- a/core/src/simulation.rs
+++ b/core/src/simulation.rs
@@ -568,14 +568,21 @@ impl SimulationEngine {
         }
     }
 
-    /// Try each healthy provider in priority order until one succeeds or all
-    /// are exhausted.
+    /// Try healthy providers in latency-ordered preference until one succeeds
+    /// or all are exhausted.
+    ///
+    /// Ordering comes from `ProviderRegistry::providers_by_latency`, which
+    /// picks the provider with the lowest EMA RTT once every candidate has
+    /// produced enough samples, and round-robins before that so new
+    /// providers aren't starved during warmup. The fallback loop itself
+    /// still visits every healthy provider — ordering only controls which
+    /// one is attempted first.
     async fn simulate_transaction_with_failover(
         &self,
         registry: &Arc<ProviderRegistry>,
         transaction_xdr: &str,
     ) -> Result<SimulationResult, SimulationError> {
-        let providers = registry.healthy_providers().await;
+        let providers = registry.providers_by_latency().await;
 
         if providers.is_empty() {
             return Err(SimulationError::RpcRequestFailed(
@@ -597,20 +604,42 @@ impl SimulationEngine {
                 .as_deref()
                 .zip(provider.auth_value.as_deref());
 
-            match self
+            let started = std::time::Instant::now();
+            let attempt = self
                 .simulate_transaction_single(
                     &provider.url,
                     auth.map(|(h, _)| h),
                     auth.map(|(_, v)| v),
                     transaction_xdr,
                 )
-                .await
-            {
+                .await;
+            let rtt_us = started.elapsed().as_micros() as u64;
+
+            match attempt {
                 Ok(result) => {
+                    // Record RTT **before** reporting success so a slow
+                    // but eventually-successful provider still contributes
+                    // a sample that pushes its EMA up — otherwise a
+                    // consistently slow provider never leaves the "top
+                    // pick" slot even after its EMA should have decayed.
+                    registry.record_rtt(&provider.url, rtt_us);
                     registry.report_success(&provider.url).await;
                     return Ok(result);
                 }
                 Err(e) => {
+                    // Only record RTT for errors that actually produced a
+                    // response from the provider. Connection-level errors
+                    // (DNS, TCP) and timeouts would poison the EMA with
+                    // values that reflect network or client state rather
+                    // than the provider's own latency.
+                    let record_sample = !matches!(
+                        &e,
+                        SimulationError::NodeTimeout | SimulationError::NetworkError(_)
+                    );
+                    if record_sample {
+                        registry.record_rtt(&provider.url, rtt_us);
+                    }
+
                     let should_retry = match &e {
                         SimulationError::NodeTimeout | SimulationError::NetworkError(_) => true,
                         SimulationError::RpcRequestFailed(msg)


### PR DESCRIPTION
## Summary

Enhances `ProviderRegistry` with real-time RTT tracking and
least-latency routing (#103).

## Problem

All healthy providers were treated as equivalent — requests were
routed in config order regardless of measured performance. A slow or
geographically distant provider received the same share of traffic as
a fast local one, dragging average and tail latency up.

## Approach

Record an exponential moving average of per-provider RTT on every
successful RPC attempt and use those EMAs to order the failover loop.
Before every provider has produced enough samples the registry falls
back to round-robin so new providers aren't starved of the traffic
they need to build up statistics. Failover behaviour is otherwise
untouched: every healthy provider is still attempted on error.

## Changes

- **`core/src/rpc_provider.rs`** — new `ProviderStats` with EMA over
  `AtomicU64` integer arithmetic (no mutex in the hot path).
  α = 2 / (window + 1), default window 20 samples (~9.5% weight on
  the newest sample). The first sample seeds the EMA directly so the
  series starts on the true value instead of ramping up from zero.
  `ProviderState` gains a `stats` field; `ProviderRegistry` gains
  `record_rtt(url, rtt_us)`, `providers_by_latency()`,
  `stats_snapshot()`, and an `AtomicUsize` cursor that drives the
  round-robin warmup path. `MIN_SAMPLES_FOR_EMA = 10` gates the
  switch from warmup to steady-state.
- **`core/src/routing.rs`** (new) — pure algorithms:
  `select_provider_index` (least-EMA with round-robin fallback and
  lowest-index tie-break) and `compute_inverse_rtt_weights` (for a
  future weighted-round-robin path). They take a `ProviderView` slice
  so tests cover every interesting scenario without booting a
  registry.
- **`core/src/simulation.rs`** — `simulate_transaction_with_failover`
  now drives its loop from `providers_by_latency()` and records the
  measured microseconds of each attempt via `record_rtt`. RTT is
  **not** recorded on `NodeTimeout` / `NetworkError` — those reflect
  client or DNS state rather than the provider's own latency and
  would poison the EMA.

## Algorithm

All arithmetic is integer microseconds: α is stored scaled by 10⁶,
the update multiplies then divides back down. No floating-point in
the request hot path.

## Testing

`core/src/rpc_provider.rs` — registry integration tests:

- `ema_converges_toward_true_value` — 100 identical samples; asserts
  EMA within ±50 µs of the true value.
- `ema_first_sample_seeds_exact_value` — the seed path bypasses the
  convex-combination formula.
- `ema_zero_window_is_clamped_safely` — a caller-supplied
  `window = 0` would have divided by zero; the constructor clamps.
- `is_warmed_reflects_sample_count_threshold` — threshold boundary.
- `providers_by_latency_picks_fastest_once_warm` — steady-state path.
- `providers_by_latency_round_robins_before_warmup` — warmup path,
  cursor rotates by one per call.
- `providers_by_latency_excludes_unhealthy_providers` — fast-but-down
  provider is skipped, slow-but-up provider is returned.
- `providers_by_latency_empty_when_all_unhealthy` — tripped pool.
- `record_rtt_for_unknown_url_is_noop` — lookup-miss safety.
- `stats_snapshot_reflects_recorded_samples` — observer endpoint
  verifies counts and EMAs per provider.

`core/src/routing.rs` — pure algorithm tests:

- `empty_pool_returns_none`, `all_unhealthy_returns_none`,
  `select_provider_picks_fastest_healthy`,
  `select_provider_falls_back_to_round_robin_before_warmup`,
  `round_robin_skips_unhealthy`,
  `unhealthy_providers_are_excluded_from_ema_pick`,
  `ties_broken_by_lowest_index`,
  `inverse_rtt_weights_favour_faster_providers`,
  `inverse_rtt_weights_skip_unhealthy`,
  `inverse_rtt_weights_on_empty_healthy_pool_return_empty`,
  `zero_rtt_is_clamped_to_one_in_weight_calc`.

### ⚠️ Build verification gap

I was unable to run `cargo test` / `cargo clippy -- -D warnings`
locally. The development machine has no working C toolchain: the
`x86_64-pc-windows-gnu` rustup default is missing `gcc.exe` and
`dlltool.exe` (required by `ring`, `windows-sys`, `getrandom`,
`parking_lot_core`), and `x86_64-pc-windows-msvc` has no C++ build
tools workload installed. `cargo check` resolves the whole dependency
graph (validating `Cargo.toml`, module wiring, and imports) before
the C-linker step fails — the failure is environmental, identical to
the block on PRs #98 and #104. Please run CI / review with fresh
eyes; no Rust-level error surfaced during the resolve phase.

## Metrics

`ProviderRegistry::stats_snapshot()` returns a `Vec<ProviderStatsSnapshot>`
with `{ name, url, ema_rtt_us, sample_count }` per provider, ready to
feed a Prometheus gauge or expose on `/health`. Wiring that snapshot
into the actual metrics endpoint is a follow-up — I did not introduce
a new metrics dependency since the project does not currently use
the `metrics` crate.

## Notes / follow-ups

- The `MIN_SAMPLES_FOR_EMA` threshold (10) and default EMA window
  (20) are compile-time constants today. Promoting both to config is
  an obvious follow-up once the operational preferences settle.
- `compute_inverse_rtt_weights` is shipped but not yet wired into any
  dispatch path — the current registry uses pure least-EMA with
  round-robin warmup. The weighted-round-robin variant is ready to
  adopt when a use case justifies it.
- `stats_snapshot` → Prometheus gauge wiring.

## Interaction with PRs #98 and #104

All three branches carry the same
`chore(workspace): exclude typed_data_auth…` commit. Whichever lands
first carries the fix; the others rebase the duplicate away cleanly.

Closes #103


