### PR TITLE
feat: implement concentrated liquidity AMM with tick math, range depo…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,6 +3310,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-typed-data-auth-contract"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-wasmi"
 version = "0.31.1-soroban.20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,6 +3327,13 @@ dependencies = [
  "wasmi_arena",
  "wasmi_core",
  "wasmparser-nostd",
+]
+
+[[package]]
+name = "soroscope-concentrated-amm"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -3353,6 +3367,13 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+]
+
+[[package]]
+name = "soroscope-math"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/contracts/concentrated_amm/Cargo.toml
+++ b/contracts/concentrated_amm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "soroscope-concentrated-amm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/concentrated_amm/src/lib.rs
+++ b/contracts/concentrated_amm/src/lib.rs
@@ -1,0 +1,585 @@
+#![no_std]
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
+
+mod math;
+use math::*;
+
+#[cfg(test)]
+mod test;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    InvalidTickRange = 3,
+    InsufficientAmount = 4,
+    SlippageExceeded = 5,
+    InvalidFee = 6,
+    MathError = 7,
+}
+
+impl From<MathError> for Error {
+    fn from(_: MathError) -> Self {
+        Error::MathError
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TickInfo {
+    pub liquidity_gross: u128,
+    pub liquidity_net: i128,
+    pub fee_growth_outside_0: u128,
+    pub fee_growth_outside_1: u128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PositionInfo {
+    pub liquidity: u128,
+    pub fee_growth_inside_0_last: u128,
+    pub fee_growth_inside_1_last: u128,
+    pub tokens_owed_0: u128,
+    pub tokens_owed_1: u128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    TokenA,
+    TokenB,
+    FeeBps,
+    TickSpacing,
+    CurrentTick,
+    CurrentSqrtPrice,
+    Liquidity,
+    FeeGrowthGlobal0,
+    FeeGrowthGlobal1,
+    Tick(i32),
+    TickBitmap(i32),
+    Position(Address, i32, i32), // Owner, TickLower, TickUpper
+}
+
+#[contract]
+pub struct ConcentratedAmm;
+
+#[contractimpl]
+impl ConcentratedAmm {
+    pub fn initialize(
+        e: Env,
+        token_a: Address,
+        token_b: Address,
+        fee_bps: u32,
+        tick_spacing: i32,
+        initial_sqrt_price_x64: u128,
+        initial_tick: i32,
+    ) -> Result<(), Error> {
+        if e.storage().instance().has(&DataKey::TokenA) {
+            return Err(Error::AlreadyInitialized);
+        }
+        
+        e.storage().instance().set(&DataKey::TokenA, &token_a);
+        e.storage().instance().set(&DataKey::TokenB, &token_b);
+        e.storage().instance().set(&DataKey::FeeBps, &fee_bps);
+        e.storage().instance().set(&DataKey::TickSpacing, &tick_spacing);
+        e.storage().instance().set(&DataKey::CurrentTick, &initial_tick);
+        e.storage().instance().set(&DataKey::CurrentSqrtPrice, &initial_sqrt_price_x64);
+        e.storage().instance().set(&DataKey::Liquidity, &0u128);
+        e.storage().instance().set(&DataKey::FeeGrowthGlobal0, &0u128);
+        e.storage().instance().set(&DataKey::FeeGrowthGlobal1, &0u128);
+        
+        Ok(())
+    }
+
+    pub fn mint(
+        e: Env,
+        to: Address,
+        tick_lower: i32,
+        tick_upper: i32,
+        amount_a_desired: u128,
+        amount_b_desired: u128,
+    ) -> Result<(u128, u128, u128), Error> {
+        to.require_auth();
+
+        let tick_spacing: i32 = e.storage().instance().get(&DataKey::TickSpacing).ok_or(Error::NotInitialized)?;
+        if tick_lower >= tick_upper || tick_lower % tick_spacing != 0 || tick_upper % tick_spacing != 0 {
+            return Err(Error::InvalidTickRange);
+        }
+
+        let current_tick: i32 = e.storage().instance().get(&DataKey::CurrentTick).unwrap();
+        let current_sqrt_price: u128 = e.storage().instance().get(&DataKey::CurrentSqrtPrice).unwrap();
+
+        let sqrt_ratio_ax64 = get_sqrt_ratio_at_tick(tick_lower)?;
+        let sqrt_ratio_bx64 = get_sqrt_ratio_at_tick(tick_upper)?;
+
+        // Use sqrt-price comparisons (mirrors Uniswap V3) so boundary ticks (e.g. tick_lower ==
+        // current_tick) don't cause division by zero in the diff_b denominator.
+        let liquidity: u128;
+        let amount_a: u128;
+        let amount_b: u128;
+
+        if current_sqrt_price <= sqrt_ratio_ax64 {
+            // Current price is at or below the range: only token A is needed.
+            let num1 = mul_div_u128(amount_a_desired, sqrt_ratio_bx64, Q64)?;
+            let num2 = mul_div_u128(num1, sqrt_ratio_ax64, Q64)?;
+            let den = sqrt_ratio_bx64.checked_sub(sqrt_ratio_ax64).ok_or(Error::MathError)?;
+            liquidity = mul_div_u128(num2, Q64, den)?;
+            amount_a = amount_a_desired;
+            amount_b = 0;
+        } else if current_sqrt_price >= sqrt_ratio_bx64 {
+            // Current price is at or above the range: only token B is needed.
+            let diff = sqrt_ratio_bx64.checked_sub(sqrt_ratio_ax64).ok_or(Error::MathError)?;
+            liquidity = mul_div_u128(amount_b_desired, Q64, diff)?;
+            amount_a = 0;
+            amount_b = amount_b_desired;
+        } else {
+            // Current price is inside the range: both tokens are needed.
+            let num1 = mul_div_u128(amount_a_desired, sqrt_ratio_bx64, Q64)?;
+            let num2 = mul_div_u128(num1, current_sqrt_price, Q64)?;
+            let den_a = sqrt_ratio_bx64.checked_sub(current_sqrt_price).ok_or(Error::MathError)?;
+            let liq_a = mul_div_u128(num2, Q64, den_a)?;
+
+            let diff_b = current_sqrt_price.checked_sub(sqrt_ratio_ax64).ok_or(Error::MathError)?;
+            let liq_b = mul_div_u128(amount_b_desired, Q64, diff_b)?;
+
+            liquidity = if liq_a < liq_b { liq_a } else { liq_b };
+            amount_a = get_amount_0_delta(current_sqrt_price, sqrt_ratio_bx64, liquidity)?;
+            amount_b = get_amount_1_delta(sqrt_ratio_ax64, current_sqrt_price, liquidity)?;
+        }
+
+        if liquidity == 0 {
+            return Err(Error::InsufficientAmount);
+        }
+
+        let token_a: Address = e.storage().instance().get(&DataKey::TokenA).unwrap();
+        let token_b: Address = e.storage().instance().get(&DataKey::TokenB).unwrap();
+        
+        if amount_a > 0 {
+            let client_a = soroban_sdk::token::Client::new(&e, &token_a);
+            client_a.transfer(&to, &e.current_contract_address(), &(amount_a as i128));
+        }
+        if amount_b > 0 {
+            let client_b = soroban_sdk::token::Client::new(&e, &token_b);
+            client_b.transfer(&to, &e.current_contract_address(), &(amount_b as i128));
+        }
+
+        let fg0: u128 = e.storage().instance().get(&DataKey::FeeGrowthGlobal0).unwrap();
+        let fg1: u128 = e.storage().instance().get(&DataKey::FeeGrowthGlobal1).unwrap();
+
+        let flipped_lower = Self::update_tick(&e, tick_lower, current_tick, liquidity as i128, fg0, fg1, false);
+        let flipped_upper = Self::update_tick(&e, tick_upper, current_tick, liquidity as i128, fg0, fg1, true);
+
+        if flipped_lower { Self::flip_tick_bitmap(&e, tick_lower, tick_spacing); }
+        if flipped_upper { Self::flip_tick_bitmap(&e, tick_upper, tick_spacing); }
+
+        let (fee_growth_inside_0, fee_growth_inside_1) = Self::get_fee_growth_inside(&e, tick_lower, tick_upper, current_tick, fg0, fg1);
+
+        let pos_key = DataKey::Position(to.clone(), tick_lower, tick_upper);
+        let mut pos: PositionInfo = e.storage().persistent().get(&pos_key).unwrap_or(PositionInfo { 
+            liquidity: 0, fee_growth_inside_0_last: fee_growth_inside_0, fee_growth_inside_1_last: fee_growth_inside_1, tokens_owed_0: 0, tokens_owed_1: 0 
+        });
+
+        // Update tokens owed
+        pos.tokens_owed_0 += mul_div_u128(pos.liquidity, fee_growth_inside_0.wrapping_sub(pos.fee_growth_inside_0_last), Q64).unwrap_or(0);
+        pos.tokens_owed_1 += mul_div_u128(pos.liquidity, fee_growth_inside_1.wrapping_sub(pos.fee_growth_inside_1_last), Q64).unwrap_or(0);
+        
+        pos.liquidity += liquidity;
+        pos.fee_growth_inside_0_last = fee_growth_inside_0;
+        pos.fee_growth_inside_1_last = fee_growth_inside_1;
+
+        e.storage().persistent().set(&pos_key, &pos);
+        e.storage().persistent().extend_ttl(&pos_key, 100, 100);
+
+        if current_tick >= tick_lower && current_tick < tick_upper {
+            let current_liq: u128 = e.storage().instance().get(&DataKey::Liquidity).unwrap_or(0);
+            e.storage().instance().set(&DataKey::Liquidity, &(current_liq + liquidity));
+        }
+
+        Ok((liquidity, amount_a, amount_b))
+    }
+
+    pub fn burn(
+        e: Env,
+        from: Address,
+        tick_lower: i32,
+        tick_upper: i32,
+        liquidity: u128,
+    ) -> Result<(u128, u128), Error> {
+        from.require_auth();
+
+        let pos_key = DataKey::Position(from.clone(), tick_lower, tick_upper);
+        let mut pos: PositionInfo = e.storage().persistent().get(&pos_key).ok_or(Error::InsufficientAmount)?;
+        
+        if pos.liquidity < liquidity {
+            return Err(Error::InsufficientAmount);
+        }
+
+        let current_tick: i32 = e.storage().instance().get(&DataKey::CurrentTick).unwrap();
+        let current_sqrt_price: u128 = e.storage().instance().get(&DataKey::CurrentSqrtPrice).unwrap();
+        let fg0: u128 = e.storage().instance().get(&DataKey::FeeGrowthGlobal0).unwrap();
+        let fg1: u128 = e.storage().instance().get(&DataKey::FeeGrowthGlobal1).unwrap();
+        
+        let sqrt_ratio_ax64 = get_sqrt_ratio_at_tick(tick_lower)?;
+        let sqrt_ratio_bx64 = get_sqrt_ratio_at_tick(tick_upper)?;
+
+        let mut amount_a: u128 = 0;
+        let mut amount_b: u128 = 0;
+
+        if current_tick < tick_lower {
+            amount_a = get_amount_0_delta(sqrt_ratio_ax64, sqrt_ratio_bx64, liquidity)?;
+        } else if current_tick >= tick_upper {
+            amount_b = get_amount_1_delta(sqrt_ratio_ax64, sqrt_ratio_bx64, liquidity)?;
+        } else {
+            amount_a = get_amount_0_delta(current_sqrt_price, sqrt_ratio_bx64, liquidity)?;
+            amount_b = get_amount_1_delta(sqrt_ratio_ax64, current_sqrt_price, liquidity)?;
+        }
+
+        let (fee_growth_inside_0, fee_growth_inside_1) = Self::get_fee_growth_inside(&e, tick_lower, tick_upper, current_tick, fg0, fg1);
+
+        pos.tokens_owed_0 += mul_div_u128(pos.liquidity, fee_growth_inside_0.wrapping_sub(pos.fee_growth_inside_0_last), Q64).unwrap_or(0);
+        pos.tokens_owed_1 += mul_div_u128(pos.liquidity, fee_growth_inside_1.wrapping_sub(pos.fee_growth_inside_1_last), Q64).unwrap_or(0);
+
+        pos.liquidity -= liquidity;
+        pos.fee_growth_inside_0_last = fee_growth_inside_0;
+        pos.fee_growth_inside_1_last = fee_growth_inside_1;
+
+        if pos.liquidity == 0 && pos.tokens_owed_0 == 0 && pos.tokens_owed_1 == 0 {
+            e.storage().persistent().remove(&pos_key);
+        } else {
+            e.storage().persistent().set(&pos_key, &pos);
+            e.storage().persistent().extend_ttl(&pos_key, 100, 100);
+        }
+
+        let tick_spacing: i32 = e.storage().instance().get(&DataKey::TickSpacing).unwrap();
+        let flipped_lower = Self::update_tick(&e, tick_lower, current_tick, -(liquidity as i128), fg0, fg1, false);
+        let flipped_upper = Self::update_tick(&e, tick_upper, current_tick, -(liquidity as i128), fg0, fg1, true);
+
+        if flipped_lower { Self::flip_tick_bitmap(&e, tick_lower, tick_spacing); }
+        if flipped_upper { Self::flip_tick_bitmap(&e, tick_upper, tick_spacing); }
+
+        if current_tick >= tick_lower && current_tick < tick_upper {
+            let current_liq: u128 = e.storage().instance().get(&DataKey::Liquidity).unwrap_or(0);
+            e.storage().instance().set(&DataKey::Liquidity, &(current_liq - liquidity));
+        }
+
+        let token_a: Address = e.storage().instance().get(&DataKey::TokenA).unwrap();
+        let token_b: Address = e.storage().instance().get(&DataKey::TokenB).unwrap();
+        
+        if amount_a > 0 {
+            let client_a = soroban_sdk::token::Client::new(&e, &token_a);
+            client_a.transfer(&e.current_contract_address(), &from, &(amount_a as i128));
+        }
+        if amount_b > 0 {
+            let client_b = soroban_sdk::token::Client::new(&e, &token_b);
+            client_b.transfer(&e.current_contract_address(), &from, &(amount_b as i128));
+        }
+
+        Ok((amount_a, amount_b))
+    }
+
+    pub fn collect_fees(
+        e: Env,
+        from: Address,
+        tick_lower: i32,
+        tick_upper: i32,
+    ) -> Result<(u128, u128), Error> {
+        from.require_auth();
+
+        let pos_key = DataKey::Position(from.clone(), tick_lower, tick_upper);
+        let mut pos: PositionInfo = e.storage().persistent().get(&pos_key).ok_or(Error::InsufficientAmount)?;
+
+        let current_tick: i32 = e.storage().instance().get(&DataKey::CurrentTick).unwrap();
+        let fg0: u128 = e.storage().instance().get(&DataKey::FeeGrowthGlobal0).unwrap();
+        let fg1: u128 = e.storage().instance().get(&DataKey::FeeGrowthGlobal1).unwrap();
+        
+        let (fee_growth_inside_0, fee_growth_inside_1) = Self::get_fee_growth_inside(&e, tick_lower, tick_upper, current_tick, fg0, fg1);
+
+        pos.tokens_owed_0 += mul_div_u128(pos.liquidity, fee_growth_inside_0.wrapping_sub(pos.fee_growth_inside_0_last), Q64).unwrap_or(0);
+        pos.tokens_owed_1 += mul_div_u128(pos.liquidity, fee_growth_inside_1.wrapping_sub(pos.fee_growth_inside_1_last), Q64).unwrap_or(0);
+
+        let amount_0 = pos.tokens_owed_0;
+        let amount_1 = pos.tokens_owed_1;
+
+        pos.tokens_owed_0 = 0;
+        pos.tokens_owed_1 = 0;
+        pos.fee_growth_inside_0_last = fee_growth_inside_0;
+        pos.fee_growth_inside_1_last = fee_growth_inside_1;
+
+        if pos.liquidity == 0 {
+            e.storage().persistent().remove(&pos_key);
+        } else {
+            e.storage().persistent().set(&pos_key, &pos);
+            e.storage().persistent().extend_ttl(&pos_key, 100, 100);
+        }
+
+        let token_a: Address = e.storage().instance().get(&DataKey::TokenA).unwrap();
+        let token_b: Address = e.storage().instance().get(&DataKey::TokenB).unwrap();
+        
+        if amount_0 > 0 {
+            let client_a = soroban_sdk::token::Client::new(&e, &token_a);
+            client_a.transfer(&e.current_contract_address(), &from, &(amount_0 as i128));
+        }
+        if amount_1 > 0 {
+            let client_b = soroban_sdk::token::Client::new(&e, &token_b);
+            client_b.transfer(&e.current_contract_address(), &from, &(amount_1 as i128));
+        }
+
+        Ok((amount_0, amount_1))
+    }
+
+    pub fn swap(
+        e: Env,
+        to: Address,
+        zero_for_one: bool,
+        amount_specified: u128,
+    ) -> Result<(u128, u128), Error> {
+        to.require_auth();
+
+        let token_a: Address = e.storage().instance().get(&DataKey::TokenA).ok_or(Error::NotInitialized)?;
+        let token_b: Address = e.storage().instance().get(&DataKey::TokenB).ok_or(Error::NotInitialized)?;
+        let fee_bps: u32 = e.storage().instance().get(&DataKey::FeeBps).unwrap();
+        let tick_spacing: i32 = e.storage().instance().get(&DataKey::TickSpacing).unwrap();
+        
+        let mut current_sqrt_price: u128 = e.storage().instance().get(&DataKey::CurrentSqrtPrice).unwrap();
+        let mut current_tick: i32 = e.storage().instance().get(&DataKey::CurrentTick).unwrap();
+        let mut liquidity: u128 = e.storage().instance().get(&DataKey::Liquidity).unwrap();
+        let mut fg0: u128 = e.storage().instance().get(&DataKey::FeeGrowthGlobal0).unwrap();
+        let mut fg1: u128 = e.storage().instance().get(&DataKey::FeeGrowthGlobal1).unwrap();
+
+        let mut amount_remaining = amount_specified;
+        let mut amount_in_total: u128 = 0;
+        let mut amount_out_total: u128 = 0;
+
+        let token_in = if zero_for_one { &token_a } else { &token_b };
+        let token_out = if zero_for_one { &token_b } else { &token_a };
+        
+        let client_in = soroban_sdk::token::Client::new(&e, token_in);
+        let client_out = soroban_sdk::token::Client::new(&e, token_out);
+
+        while amount_remaining > 0 {
+            if liquidity == 0 {
+                // No liquidity at current price; advance to next initialized tick or stop.
+                let (next_tick, initialized) = Self::next_initialized_tick_within_one_word(&e, current_tick, tick_spacing, zero_for_one);
+                if !initialized {
+                    break;
+                }
+                // Cross the empty tick to activate its liquidity, then continue.
+                let tick_key = DataKey::Tick(next_tick);
+                if let Some(mut tick_info) = e.storage().persistent().get::<_, TickInfo>(&tick_key) {
+                    tick_info.fee_growth_outside_0 = fg0.wrapping_sub(tick_info.fee_growth_outside_0);
+                    tick_info.fee_growth_outside_1 = fg1.wrapping_sub(tick_info.fee_growth_outside_1);
+                    e.storage().persistent().set(&tick_key, &tick_info);
+                    let net = if zero_for_one { -tick_info.liquidity_net } else { tick_info.liquidity_net };
+                    if net < 0 {
+                        liquidity = liquidity.saturating_sub((-net) as u128);
+                    } else {
+                        liquidity = liquidity.saturating_add(net as u128);
+                    }
+                }
+                current_tick = if zero_for_one { next_tick - 1 } else { next_tick };
+                current_sqrt_price = get_sqrt_ratio_at_tick(current_tick)?;
+                continue;
+            }
+
+            let (next_tick, initialized) = Self::next_initialized_tick_within_one_word(&e, current_tick, tick_spacing, zero_for_one);
+            let sqrt_price_next = get_sqrt_ratio_at_tick(next_tick)?;
+
+            let amount_remaining_less_fee = mul_div_u128(amount_remaining, 10000 - (fee_bps as u128), 10000)?;
+
+            let max_amount_in = if zero_for_one {
+                get_amount_0_delta(current_sqrt_price, sqrt_price_next, liquidity).unwrap_or(u128::MAX)
+            } else {
+                get_amount_1_delta(current_sqrt_price, sqrt_price_next, liquidity).unwrap_or(u128::MAX)
+            };
+
+            let crossed = amount_remaining_less_fee >= max_amount_in && initialized;
+            let amount_in_step = if crossed { max_amount_in } else { amount_remaining_less_fee };
+            
+            let amount_out_step = if crossed {
+                if zero_for_one {
+                    get_amount_1_delta(current_sqrt_price, sqrt_price_next, liquidity)?
+                } else {
+                    get_amount_0_delta(current_sqrt_price, sqrt_price_next, liquidity)?
+                }
+            } else {
+                let next_p = get_next_sqrt_price_from_input(current_sqrt_price, liquidity, amount_in_step, zero_for_one)?;
+                if zero_for_one {
+                    get_amount_1_delta(current_sqrt_price, next_p, liquidity)?
+                } else {
+                    get_amount_0_delta(current_sqrt_price, next_p, liquidity)?
+                }
+            };
+
+            // Calculate exact fee collected during this step
+            let fee_amount = if crossed {
+                mul_div_u128(amount_in_step, fee_bps as u128, 10000 - (fee_bps as u128))?
+            } else {
+                amount_remaining - amount_remaining_less_fee
+            };
+
+            if liquidity > 0 {
+                let fee_growth = mul_div_u128(fee_amount, Q64, liquidity)?;
+                if zero_for_one {
+                    fg0 = fg0.wrapping_add(fee_growth);
+                } else {
+                    fg1 = fg1.wrapping_add(fee_growth);
+                }
+            }
+
+            amount_in_total += amount_in_step + fee_amount;
+            amount_out_total += amount_out_step;
+            amount_remaining = amount_remaining.saturating_sub(amount_in_step + fee_amount);
+
+            if crossed {
+                current_sqrt_price = sqrt_price_next;
+                current_tick = if zero_for_one { next_tick - 1 } else { next_tick };
+
+                let mut tick_info: TickInfo = e.storage().persistent().get(&DataKey::Tick(next_tick)).unwrap();
+                tick_info.fee_growth_outside_0 = fg0.wrapping_sub(tick_info.fee_growth_outside_0);
+                tick_info.fee_growth_outside_1 = fg1.wrapping_sub(tick_info.fee_growth_outside_1);
+                e.storage().persistent().set(&DataKey::Tick(next_tick), &tick_info);
+
+                let net = if zero_for_one { -tick_info.liquidity_net } else { tick_info.liquidity_net };
+                if net < 0 {
+                    liquidity = liquidity.saturating_sub((-net) as u128);
+                } else {
+                    liquidity = liquidity.saturating_add(net as u128);
+                }
+            } else {
+                current_sqrt_price = get_next_sqrt_price_from_input(current_sqrt_price, liquidity, amount_in_step, zero_for_one)?;
+            }
+        }
+
+        e.storage().instance().set(&DataKey::CurrentSqrtPrice, &current_sqrt_price);
+        e.storage().instance().set(&DataKey::CurrentTick, &current_tick);
+        e.storage().instance().set(&DataKey::Liquidity, &liquidity);
+        e.storage().instance().set(&DataKey::FeeGrowthGlobal0, &fg0);
+        e.storage().instance().set(&DataKey::FeeGrowthGlobal1, &fg1);
+
+        client_in.transfer(&to, &e.current_contract_address(), &(amount_in_total as i128));
+        client_out.transfer(&e.current_contract_address(), &to, &(amount_out_total as i128));
+
+        Ok((amount_in_total, amount_out_total))
+    }
+
+    fn update_tick(e: &Env, tick: i32, current_tick: i32, liquidity_delta: i128, fg0: u128, fg1: u128, is_upper: bool) -> bool {
+        let tick_key = DataKey::Tick(tick);
+        let mut info: TickInfo = e.storage().persistent().get(&tick_key).unwrap_or(TickInfo { 
+            liquidity_gross: 0, liquidity_net: 0, fee_growth_outside_0: 0, fee_growth_outside_1: 0 
+        });
+        
+        let liquidity_gross_before = info.liquidity_gross;
+        
+        if liquidity_gross_before == 0 {
+            if tick <= current_tick {
+                info.fee_growth_outside_0 = fg0;
+                info.fee_growth_outside_1 = fg1;
+            }
+        }
+
+        let delta = if is_upper { -liquidity_delta } else { liquidity_delta };
+        info.liquidity_net += delta;
+        if liquidity_delta < 0 {
+            info.liquidity_gross = info.liquidity_gross.saturating_sub((-liquidity_delta) as u128);
+        } else {
+            info.liquidity_gross = info.liquidity_gross.saturating_add(liquidity_delta as u128);
+        }
+
+        let flipped = (liquidity_gross_before == 0 && info.liquidity_gross > 0) || (liquidity_gross_before > 0 && info.liquidity_gross == 0);
+
+        if info.liquidity_gross == 0 {
+            e.storage().persistent().remove(&tick_key);
+        } else {
+            e.storage().persistent().set(&tick_key, &info);
+            e.storage().persistent().extend_ttl(&tick_key, 100, 100);
+        }
+        
+        flipped
+    }
+
+    fn flip_tick_bitmap(e: &Env, tick: i32, tick_spacing: i32) {
+        let compressed = tick / tick_spacing;
+        let word_pos = compressed >> 6;
+        let bit_pos = (compressed & 0x3F) as u64;
+        let mask = 1u64 << bit_pos;
+
+        let key = DataKey::TickBitmap(word_pos);
+        let mut word: u64 = e.storage().persistent().get(&key).unwrap_or(0);
+        word ^= mask;
+        
+        if word == 0 {
+            e.storage().persistent().remove(&key);
+        } else {
+            e.storage().persistent().set(&key, &word);
+            e.storage().persistent().extend_ttl(&key, 100, 100);
+        }
+    }
+
+    fn next_initialized_tick_within_one_word(e: &Env, tick: i32, tick_spacing: i32, lte: bool) -> (i32, bool) {
+        let compressed = if tick < 0 && tick % tick_spacing != 0 {
+            (tick / tick_spacing) - 1
+        } else {
+            tick / tick_spacing
+        };
+
+        if lte {
+            let word_pos = compressed >> 6;
+            let bit_pos = (compressed & 0x3F) as u32;
+            let mask = (1u64 << bit_pos) - 1 + (1u64 << bit_pos);
+            let word: u64 = e.storage().persistent().get(&DataKey::TickBitmap(word_pos)).unwrap_or(0);
+            let masked = word & mask;
+
+            if masked != 0 {
+                let bit = 63 - masked.leading_zeros();
+                ((word_pos * 64 + bit as i32) * tick_spacing, true)
+            } else {
+                ((word_pos * 64) * tick_spacing, false)
+            }
+        } else {
+            let compressed_next = compressed + 1;
+            let word_pos = compressed_next >> 6;
+            let bit_pos = (compressed_next & 0x3F) as u32;
+            let mask = !((1u64 << bit_pos) - 1);
+            let word: u64 = e.storage().persistent().get(&DataKey::TickBitmap(word_pos)).unwrap_or(0);
+            let masked = word & mask;
+
+            if masked != 0 {
+                let bit = masked.trailing_zeros();
+                ((word_pos * 64 + bit as i32) * tick_spacing, true)
+            } else {
+                (((word_pos + 1) * 64 - 1) * tick_spacing, false)
+            }
+        }
+    }
+
+    fn get_fee_growth_inside(
+        e: &Env, 
+        tick_lower: i32, 
+        tick_upper: i32, 
+        tick_current: i32, 
+        fg0: u128, 
+        fg1: u128
+    ) -> (u128, u128) {
+        let lower_info: TickInfo = e.storage().persistent().get(&DataKey::Tick(tick_lower)).unwrap_or(TickInfo { liquidity_gross: 0, liquidity_net: 0, fee_growth_outside_0: 0, fee_growth_outside_1: 0 });
+        let upper_info: TickInfo = e.storage().persistent().get(&DataKey::Tick(tick_upper)).unwrap_or(TickInfo { liquidity_gross: 0, liquidity_net: 0, fee_growth_outside_0: 0, fee_growth_outside_1: 0 });
+
+        let (fee_below_0, fee_below_1) = if tick_current >= tick_lower {
+            (lower_info.fee_growth_outside_0, lower_info.fee_growth_outside_1)
+        } else {
+            (fg0.wrapping_sub(lower_info.fee_growth_outside_0), fg1.wrapping_sub(lower_info.fee_growth_outside_1))
+        };
+
+        let (fee_above_0, fee_above_1) = if tick_current < tick_upper {
+            (upper_info.fee_growth_outside_0, upper_info.fee_growth_outside_1)
+        } else {
+            (fg0.wrapping_sub(upper_info.fee_growth_outside_0), fg1.wrapping_sub(upper_info.fee_growth_outside_1))
+        };
+
+        (
+            fg0.wrapping_sub(fee_below_0).wrapping_sub(fee_above_0),
+            fg1.wrapping_sub(fee_below_1).wrapping_sub(fee_above_1),
+        )
+    }
+}

--- a/contracts/concentrated_amm/src/math.rs
+++ b/contracts/concentrated_amm/src/math.rs
@@ -1,0 +1,126 @@
+#![no_std]
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum MathError {
+    Overflow = 1,
+    DivisionByZero = 2,
+    InvalidPrice = 3,
+}
+
+pub const Q64: u128 = 1 << 64;
+
+pub fn mul_div_u128(a: u128, b: u128, d: u128) -> Result<u128, MathError> {
+    if d == 0 { return Err(MathError::DivisionByZero); }
+    if let Some(prod) = a.checked_mul(b) { return Ok(prod / d); }
+    let a_low = a & 0xFFFFFFFFFFFFFFFF;
+    let a_high = a >> 64;
+    let b_low = b & 0xFFFFFFFFFFFFFFFF;
+    let b_high = b >> 64;
+    let p0 = a_low * b_low;
+    let p1 = a_low * b_high;
+    let p2 = a_high * b_low;
+    let p3 = a_high * b_high;
+    let mut mid = (p1 & 0xFFFFFFFFFFFFFFFF) + (p2 & 0xFFFFFFFFFFFFFFFF) + (p0 >> 64);
+    let high = p3 + (p1 >> 64) + (p2 >> 64) + (mid >> 64);
+    let low = (mid << 64) | (p0 & 0xFFFFFFFFFFFFFFFF);
+    if high >= d { return Err(MathError::Overflow); }
+    let mut quotient = 0u128;
+    let mut remainder = high;
+    for i in (0..128).rev() {
+        remainder = (remainder << 1) | ((low >> i) & 1);
+        if remainder >= d { remainder -= d; quotient |= 1 << i; }
+    }
+    Ok(quotient)
+}
+
+/// Sqrt Price X64 mapping:
+/// We represent price as Q64.64. tick is integer. 
+/// Price = 1.0001 ^ tick. SqrtPrice = 1.0001 ^ (tick / 2).
+/// We approximate it for the sake of this task to avoid heavy exponentiation
+/// if not needed, or implement a basic version.
+pub fn get_sqrt_ratio_at_tick(tick: i32) -> Result<u128, MathError> {
+    let abs_tick = tick.abs() as u32;
+    // 1.00005 in Q64 = 18447669818844880896
+    let base: u128 = 18447669818844880896; 
+    let mut ratio: u128 = Q64;
+    let mut current_base = base;
+    let mut t = abs_tick;
+    
+    while t > 0 {
+        if t % 2 == 1 {
+            ratio = mul_div_u128(ratio, current_base, Q64)?;
+        }
+        current_base = mul_div_u128(current_base, current_base, Q64)?;
+        t /= 2;
+    }
+    
+    if tick < 0 {
+        ratio = mul_div_u128(Q64, Q64, ratio)?;
+    }
+    
+    Ok(ratio)
+}
+
+/// Computes the amount of token 0 (token A) for a given liquidity and price range
+/// delta_amount0 = liquidity * (sqrt(upper) - sqrt(lower)) / (sqrt(upper) * sqrt(lower))
+pub fn get_amount_0_delta(
+    sqrt_ratio_ax64: u128,
+    sqrt_ratio_bx64: u128,
+    liquidity: u128,
+) -> Result<u128, MathError> {
+    let (lower, upper) = if sqrt_ratio_ax64 < sqrt_ratio_bx64 {
+        (sqrt_ratio_ax64, sqrt_ratio_bx64)
+    } else {
+        (sqrt_ratio_bx64, sqrt_ratio_ax64)
+    };
+    
+    // num1 = liquidity << 64
+    // num2 = upper - lower
+    // den = upper * lower
+    // Actually, amount0 = (liquidity * (upper - lower)) / upper / lower * 2^64
+    let num1 = mul_div_u128(liquidity, Q64, upper)?;
+    let num2 = upper.checked_sub(lower).ok_or(MathError::Overflow)?;
+    let amount0 = mul_div_u128(num1, num2, lower)?;
+    Ok(amount0)
+}
+
+/// Computes the amount of token 1 (token B) for a given liquidity and price range
+/// delta_amount1 = liquidity * (sqrt(upper) - sqrt(lower))
+pub fn get_amount_1_delta(
+    sqrt_ratio_ax64: u128,
+    sqrt_ratio_bx64: u128,
+    liquidity: u128,
+) -> Result<u128, MathError> {
+    let (lower, upper) = if sqrt_ratio_ax64 < sqrt_ratio_bx64 {
+        (sqrt_ratio_ax64, sqrt_ratio_bx64)
+    } else {
+        (sqrt_ratio_bx64, sqrt_ratio_ax64)
+    };
+    
+    let diff = upper.checked_sub(lower).ok_or(MathError::Overflow)?;
+    mul_div_u128(liquidity, diff, Q64)
+}
+
+pub fn get_next_sqrt_price_from_input(
+    sqrt_px64: u128,
+    liquidity: u128,
+    amount_in: u128,
+    zero_for_one: bool,
+) -> Result<u128, MathError> {
+    if amount_in == 0 { return Ok(sqrt_px64); }
+    
+    if zero_for_one {
+        // next_P_q64 = sqrt_px64 * L / (L + Δx * sqrt_P_real)
+        // where sqrt_P_real = sqrt_px64 / Q64
+        let p_real_times_delta = mul_div_u128(amount_in, sqrt_px64, Q64)?;
+        let den = liquidity.checked_add(p_real_times_delta).ok_or(MathError::Overflow)?;
+        mul_div_u128(sqrt_px64, liquidity, den)
+    } else {
+        // next_P = sqrt_P + (amount_in / L)
+        let delta = mul_div_u128(amount_in, Q64, liquidity)?;
+        sqrt_px64.checked_add(delta).ok_or(MathError::Overflow)
+    }
+}

--- a/contracts/concentrated_amm/src/test.rs
+++ b/contracts/concentrated_amm/src/test.rs
@@ -1,0 +1,388 @@
+#![cfg(test)]
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use crate::{ConcentratedAmm, ConcentratedAmmClient};
+
+// 1.0 in Q64 fixed-point
+const Q64: u128 = 1u128 << 64;
+
+/// Registers two stellar asset contracts and returns (token_a_addr, token_b_addr,
+/// token_a_admin_client, token_b_admin_client).
+fn setup_tokens(e: &Env) -> (
+    Address,
+    Address,
+    soroban_sdk::token::StellarAssetClient,
+    soroban_sdk::token::StellarAssetClient,
+) {
+    let admin = Address::generate(e);
+    let token_a_addr = e.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_b_addr = e.register_stellar_asset_contract_v2(admin.clone()).address();
+    let admin_a = soroban_sdk::token::StellarAssetClient::new(e, &token_a_addr);
+    let admin_b = soroban_sdk::token::StellarAssetClient::new(e, &token_b_addr);
+    (token_a_addr, token_b_addr, admin_a, admin_b)
+}
+
+/// Deploys the AMM and initialises it at tick=0 (sqrt_price=Q64), tick_spacing=10, fee=30bps.
+fn setup_amm<'a>(e: &'a Env, token_a: &Address, token_b: &Address) -> ConcentratedAmmClient<'a> {
+    let contract_id = e.register(ConcentratedAmm, ());
+    let client = ConcentratedAmmClient::new(e, &contract_id);
+    client.initialize(token_a, token_b, &30u32, &10i32, &Q64, &0i32);
+    client
+}
+
+#[test]
+fn test_initialization() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register(ConcentratedAmm, ());
+    let client = ConcentratedAmmClient::new(&e, &contract_id);
+
+    let token_a = Address::generate(&e);
+    let token_b = Address::generate(&e);
+
+    client.initialize(&token_a, &token_b, &30, &10, &Q64, &0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_double_initialization() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (token_a, token_b, _, _) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    // Second call must fail with AlreadyInitialized.
+    client.initialize(&token_a, &token_b, &30, &10, &Q64, &0);
+}
+
+#[test]
+fn test_mint_in_range() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let user = Address::generate(&e);
+    admin_a.mint(&user, &1_000_000);
+    admin_b.mint(&user, &1_000_000);
+
+    // Tick range [-100, 100] straddles the current tick (0), so both tokens are deposited.
+    let (liq, amt_a, amt_b) = client.mint(&user, &-100i32, &100i32, &100_000u128, &100_000u128);
+
+    assert!(liq > 0, "should mint positive liquidity");
+    assert!(amt_a > 0, "in-range mint should consume token A");
+    assert!(amt_b > 0, "in-range mint should consume token B");
+    assert!(amt_a <= 100_000, "should not over-consume token A");
+    assert!(amt_b <= 100_000, "should not over-consume token B");
+}
+
+#[test]
+fn test_mint_below_range() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let user = Address::generate(&e);
+    admin_a.mint(&user, &1_000_000);
+    admin_b.mint(&user, &1_000_000);
+
+    // Range [200, 400] is fully above the current price (tick 0), so only token A is consumed.
+    let (liq, amt_a, amt_b) = client.mint(&user, &200i32, &400i32, &100_000u128, &0u128);
+
+    assert!(liq > 0);
+    assert!(amt_a > 0, "below-range mint consumes only token A");
+    assert_eq!(amt_b, 0, "below-range mint uses no token B");
+}
+
+#[test]
+fn test_mint_above_range() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let user = Address::generate(&e);
+    admin_a.mint(&user, &1_000_000);
+    admin_b.mint(&user, &1_000_000);
+
+    // Range [-400, -200] is fully below the current price (tick 0), so only token B is consumed.
+    let (liq, amt_a, amt_b) = client.mint(&user, &-400i32, &-200i32, &0u128, &100_000u128);
+
+    assert!(liq > 0);
+    assert_eq!(amt_a, 0, "above-range mint uses no token A");
+    assert!(amt_b > 0, "above-range mint consumes only token B");
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_mint_invalid_tick_range() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, _) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let user = Address::generate(&e);
+    admin_a.mint(&user, &1_000_000);
+
+    // tick_lower >= tick_upper — must fail with InvalidTickRange.
+    client.mint(&user, &100i32, &-100i32, &100_000u128, &100_000u128);
+}
+
+#[test]
+fn test_burn_recovers_tokens() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let user = Address::generate(&e);
+    admin_a.mint(&user, &1_000_000);
+    admin_b.mint(&user, &1_000_000);
+
+    let (liq, amt_a_in, amt_b_in) = client.mint(&user, &-100i32, &100i32, &100_000u128, &100_000u128);
+
+    let client_a = soroban_sdk::token::Client::new(&e, &token_a);
+    let client_b = soroban_sdk::token::Client::new(&e, &token_b);
+
+    let bal_a_before = client_a.balance(&user);
+    let bal_b_before = client_b.balance(&user);
+
+    let (recovered_a, recovered_b) = client.burn(&user, &-100i32, &100i32, &liq);
+
+    let bal_a_after = client_a.balance(&user);
+    let bal_b_after = client_b.balance(&user);
+
+    assert_eq!(recovered_a, amt_a_in, "should recover all of token A");
+    assert_eq!(recovered_b, amt_b_in, "should recover all of token B");
+    assert_eq!(bal_a_after - bal_a_before, recovered_a as i128);
+    assert_eq!(bal_b_after - bal_b_before, recovered_b as i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_burn_more_than_owned() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let user = Address::generate(&e);
+    admin_a.mint(&user, &1_000_000);
+    admin_b.mint(&user, &1_000_000);
+
+    let (liq, _, _) = client.mint(&user, &-100i32, &100i32, &100_000u128, &100_000u128);
+
+    // Attempt to burn more liquidity than minted.
+    client.burn(&user, &-100i32, &100i32, &(liq + 1));
+}
+
+#[test]
+fn test_swap_zero_for_one_within_range() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let lp = Address::generate(&e);
+    let trader = Address::generate(&e);
+
+    admin_a.mint(&lp, &10_000_000);
+    admin_b.mint(&lp, &10_000_000);
+    admin_a.mint(&trader, &1_000_000);
+    admin_b.mint(&trader, &1_000_000);
+
+    // Provide wide in-range liquidity.
+    client.mint(&lp, &-500i32, &500i32, &5_000_000u128, &5_000_000u128);
+
+    let client_a = soroban_sdk::token::Client::new(&e, &token_a);
+    let client_b = soroban_sdk::token::Client::new(&e, &token_b);
+
+    let bal_a_before = client_a.balance(&trader);
+    let bal_b_before = client_b.balance(&trader);
+
+    // Sell token A, receive token B (zero_for_one = true).
+    let (amt_in, amt_out) = client.swap(&trader, &true, &10_000u128);
+
+    assert!(amt_in > 0);
+    assert!(amt_out > 0);
+    assert_eq!(client_a.balance(&trader), bal_a_before - amt_in as i128);
+    assert_eq!(client_b.balance(&trader), bal_b_before + amt_out as i128);
+}
+
+#[test]
+fn test_swap_one_for_zero_within_range() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let lp = Address::generate(&e);
+    let trader = Address::generate(&e);
+
+    admin_a.mint(&lp, &10_000_000);
+    admin_b.mint(&lp, &10_000_000);
+    admin_a.mint(&trader, &1_000_000);
+    admin_b.mint(&trader, &1_000_000);
+
+    client.mint(&lp, &-500i32, &500i32, &5_000_000u128, &5_000_000u128);
+
+    let client_a = soroban_sdk::token::Client::new(&e, &token_a);
+    let client_b = soroban_sdk::token::Client::new(&e, &token_b);
+
+    let bal_a_before = client_a.balance(&trader);
+    let bal_b_before = client_b.balance(&trader);
+
+    // Sell token B, receive token A (zero_for_one = false).
+    let (amt_in, amt_out) = client.swap(&trader, &false, &10_000u128);
+
+    assert!(amt_in > 0);
+    assert!(amt_out > 0);
+    assert_eq!(client_b.balance(&trader), bal_b_before - amt_in as i128);
+    assert_eq!(client_a.balance(&trader), bal_a_before + amt_out as i128);
+}
+
+#[test]
+fn test_swap_crosses_tick() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let lp1 = Address::generate(&e);
+    let lp2 = Address::generate(&e);
+    let trader = Address::generate(&e);
+
+    admin_a.mint(&lp1, &10_000_000);
+    admin_b.mint(&lp1, &10_000_000);
+    admin_a.mint(&lp2, &10_000_000);
+    admin_b.mint(&lp2, &10_000_000);
+    admin_a.mint(&trader, &10_000_000);
+    admin_b.mint(&trader, &10_000_000);
+
+    // Two adjacent liquidity bands: [-500, 0] and [0, 500].
+    client.mint(&lp1, &-500i32, &0i32, &2_000_000u128, &2_000_000u128);
+    client.mint(&lp2, &0i32, &500i32, &2_000_000u128, &2_000_000u128);
+
+    let client_a = soroban_sdk::token::Client::new(&e, &token_a);
+    let client_b = soroban_sdk::token::Client::new(&e, &token_b);
+
+    let bal_b_before = client_b.balance(&trader);
+
+    // Large swap that should cross tick 0 and continue into the [-500, 0] band.
+    let (amt_in, amt_out) = client.swap(&trader, &true, &3_000_000u128);
+
+    assert!(amt_in > 0);
+    assert!(amt_out > 0);
+    // Trader paid token A and received token B.
+    assert!(client_b.balance(&trader) > bal_b_before, "trader should have received token B");
+    let _ = client_a.balance(&trader); // just access to ensure no panic
+}
+
+#[test]
+fn test_collect_fees_after_swap() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let lp = Address::generate(&e);
+    let trader = Address::generate(&e);
+
+    admin_a.mint(&lp, &10_000_000);
+    admin_b.mint(&lp, &10_000_000);
+    admin_a.mint(&trader, &1_000_000);
+    admin_b.mint(&trader, &1_000_000);
+
+    client.mint(&lp, &-500i32, &500i32, &5_000_000u128, &5_000_000u128);
+
+    // Do several swaps to accumulate fees.
+    client.swap(&trader, &true, &50_000u128);
+    client.swap(&trader, &false, &50_000u128);
+    client.swap(&trader, &true, &50_000u128);
+
+    // LP collects fees; should get some positive amount of at least one token.
+    let (fee0, fee1) = client.collect_fees(&lp, &-500i32, &500i32);
+    assert!(fee0 > 0 || fee1 > 0, "LP should have earned fees from swaps");
+}
+
+#[test]
+fn test_multiple_lps_independent_positions() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let lp1 = Address::generate(&e);
+    let lp2 = Address::generate(&e);
+
+    admin_a.mint(&lp1, &1_000_000);
+    admin_b.mint(&lp1, &1_000_000);
+    admin_a.mint(&lp2, &1_000_000);
+    admin_b.mint(&lp2, &1_000_000);
+
+    // Same range for both LPs.
+    let (liq1, _, _) = client.mint(&lp1, &-100i32, &100i32, &100_000u128, &100_000u128);
+    let (liq2, _, _) = client.mint(&lp2, &-100i32, &100i32, &100_000u128, &100_000u128);
+
+    assert!(liq1 > 0);
+    assert!(liq2 > 0);
+
+    // Burn lp1's position independently.
+    let (a1, b1) = client.burn(&lp1, &-100i32, &100i32, &liq1);
+    assert!(a1 > 0 || b1 > 0);
+
+    // lp2's position is unaffected.
+    let (a2, b2) = client.burn(&lp2, &-100i32, &100i32, &liq2);
+    assert!(a2 > 0 || b2 > 0);
+}
+
+#[test]
+fn test_partial_burn() {
+    let e = Env::default();
+    e.mock_all_auths();
+    e.cost_estimate().budget().reset_unlimited();
+
+    let (token_a, token_b, admin_a, admin_b) = setup_tokens(&e);
+    let client = setup_amm(&e, &token_a, &token_b);
+
+    let lp = Address::generate(&e);
+    admin_a.mint(&lp, &1_000_000);
+    admin_b.mint(&lp, &1_000_000);
+
+    let (liq, _, _) = client.mint(&lp, &-100i32, &100i32, &100_000u128, &100_000u128);
+
+    // Burn half the liquidity.
+    let half = liq / 2;
+    let (a1, b1) = client.burn(&lp, &-100i32, &100i32, &half);
+    assert!(a1 > 0 || b1 > 0, "partial burn should recover tokens");
+
+    // Burn the remainder.
+    let (a2, b2) = client.burn(&lp, &-100i32, &100i32, &(liq - half));
+    assert!(a2 > 0 || b2 > 0, "remaining burn should also recover tokens");
+}


### PR DESCRIPTION
## Summary

Closes #123

Implements a Uniswap V3-style Concentrated Liquidity AMM on Soroban, allowing liquidity providers to deposit into specific price ranges (ticks) rather than across the full curve.

### What's in this PR

**`contracts/concentrated_amm/src/math.rs` — Tick-based math**
- Q64 fixed-point arithmetic (`mul_div_u128`) with 256-bit intermediate handling
- `get_sqrt_ratio_at_tick` — maps tick index → sqrt price via binary exponentiation of `√1.0001`
- `get_amount_0_delta` / `get_amount_1_delta` — token amounts for a given liquidity and price range
- `get_next_sqrt_price_from_input` — computes next sqrt price after a swap step (both directions)

**`contracts/concentrated_amm/src/lib.rs` — Core contract logic**
- `initialize` — sets token pair, fee, tick spacing, and initial sqrt price
- `mint` — range-based liquidity deposit; handles below-range (token A only), above-range (token B only), and in-range (both tokens) cases; updates tick states and the tick bitmap
- `burn` — range-based liquidity withdrawal; mirrors mint accounting and returns proportional tokens
- `collect_fees` — claims accumulated swap fees for a position using per-tick fee growth checkpoints
- `swap` — dynamic swap that steps through initialized ticks, applies fees per step, flips fee growth references on tick crossing, and updates global liquidity as ticks are crossed

**`contracts/concentrated_amm/src/test.rs` — Test suite (14 tests)**

| Test | What it covers |
|---|---|
| `test_initialization` | Pool initialises correctly |
| `test_double_initialization` | Second init reverts |
| `test_mint_in_range` | Both tokens consumed when price is inside range |
| `test_mint_below_range` | Only token A consumed when price is below range |
| `test_mint_above_range` | Only token B consumed when price is above range |
| `test_mint_invalid_tick_range` | Reverts on bad tick order |
| `test_burn_recovers_tokens` | Full burn returns exact deposited amounts |
| `test_burn_more_than_owned` | Reverts when burning excess liquidity |
| `test_partial_burn` | Two sequential partial burns exhaust position correctly |
| `test_swap_zero_for_one_within_range` | Token A → B swap within a single tick range |
| `test_swap_one_for_zero_within_range` | Token B → A swap within a single tick range |
| `test_swap_crosses_tick` | Large swap crosses a tick boundary and continues |
| `test_collect_fees_after_swap` | LP earns non-zero fees after multiple swaps |
| `test_multiple_lps_independent_positions` | Two LPs in the same range have independent positions |

<img width="714" height="381" alt="Screenshot 2026-04-25 at 8 01 20 PM" src="https://github.com/user-attachments/assets/b61d0053-729c-49f0-bf07-30e67d1a7f34" />


### Bugs fixed during implementation

| Bug | Fix |
|---|---|
| `DataKey::TickBitmap(i16)` — `i16` not supported by Soroban `#[contracttype]` | Changed to `i32` |
| Wrong `get_next_sqrt_price_from_input` formula for `zero_for_one=true` | Corrected to `P_q64 * L / (L + Δx * P_real)` |
| Division by zero in `mint` when `current_tick == tick_lower` | Switched branch condition from tick comparison to sqrt-price comparison (≤ / ≥), matching Uniswap V3 reference |
| Potential infinite loop in `swap` when `liquidity == 0` | Added early-exit guard that advances past empty ranges or breaks when no initialized tick exists |

### Known simplifications (intentional for a benchmarking contract)

- `get_sqrt_ratio_at_tick` uses `1.00005^tick` approximation rather than Uniswap V3's 20-constant precomputed table
- No `sqrt_price_limit` slippage cap on `swap`
- `current_tick` is not back-calculated from the new sqrt price after a partial (non-crossing) swap step

