### PR TITLE
Backend: JWT-RS256 Migration for API Authentication

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,3 +36,4 @@ sqlx = { version = "0.7", features = ["runtime-tokio", "tls-native-tls", "postgr
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+rsa = "0.9"

--- a/core/src/auth.rs
+++ b/core/src/auth.rs
@@ -1,9 +1,10 @@
 use crate::errors::AppError;
 use axum::{extract::Request, http::header, middleware::Next, response::Response, Extension, Json};
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use base64::{engine::general_purpose::STANDARD as BASE64, engine::general_purpose::URL_SAFE_NO_PAD as BASE64_URL, Engine};
 use ed25519_dalek::{Signature as Ed25519Signature, Signer, SigningKey, Verifier, VerifyingKey};
-use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use rand::RngCore;
+use rsa::{pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey}, RsaPrivateKey, RsaPublicKey, traits::PublicKeyParts};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use soroban_sdk::xdr::{
@@ -21,7 +22,10 @@ const JWT_EXPIRY_SECS: u64 = 86400;
 const WEB_AUTH_DOMAIN: &str = "soroscope";
 
 pub struct AuthState {
-    pub jwt_secret: String,
+    pub encoding_key: EncodingKey,
+    pub decoding_key: DecodingKey,
+    pub jwk_n: String,
+    pub jwk_e: String,
     pub signing_key: SigningKey,
     pub server_public_key: [u8; 32],
     pub network_passphrase: String,
@@ -29,7 +33,7 @@ pub struct AuthState {
 
 impl AuthState {
     pub fn new(
-        jwt_secret: String,
+        jwt_private_key_pem: Option<String>,
         sep10_seed: Option<[u8; 32]>,
         network_passphrase: String,
     ) -> Self {
@@ -42,8 +46,30 @@ impl AuthState {
             }
         };
         let server_public_key = signing_key.verifying_key().to_bytes();
+
+        let priv_key = if let Some(pem) = jwt_private_key_pem {
+            RsaPrivateKey::from_pkcs8_pem(&pem).expect("Invalid RSA Private Key PEM")
+        } else {
+            tracing::info!("Generating ephemeral RSA keypair for local development...");
+            let mut rng = rand::thread_rng();
+            RsaPrivateKey::new(&mut rng, 2048).expect("Failed to generate RSA key")
+        };
+
+        let pem_str = priv_key.to_pkcs8_pem(rsa::pkcs8::LineEnding::LF).unwrap();
+        let encoding_key = EncodingKey::from_rsa_pem(pem_str.as_bytes()).unwrap();
+
+        let pub_key = RsaPublicKey::from(&priv_key);
+        let pub_pem = pub_key.to_public_key_pem(rsa::pkcs8::LineEnding::LF).unwrap();
+        let decoding_key = DecodingKey::from_rsa_pem(pub_pem.as_bytes()).unwrap();
+
+        let n = BASE64_URL.encode(pub_key.n().to_bytes_be());
+        let e = BASE64_URL.encode(pub_key.e().to_bytes_be());
+
         Self {
-            jwt_secret,
+            encoding_key,
+            decoding_key,
+            jwk_n: n,
+            jwk_e: e,
             signing_key,
             server_public_key,
             network_passphrase,
@@ -84,6 +110,7 @@ struct Claims {
     iss: String,
     exp: u64,
     iat: u64,
+    scopes: Vec<String>,
 }
 
 fn now_secs() -> u64 {
@@ -305,12 +332,14 @@ fn verify_challenge_envelope(state: &AuthState, signed_xdr_b64: &str) -> Result<
         iss: WEB_AUTH_DOMAIN.to_string(),
         iat: now,
         exp: now + JWT_EXPIRY_SECS,
+        scopes: vec!["simulate".to_string()],
     };
 
+    let header = Header::new(Algorithm::RS256);
     encode(
-        &Header::default(),
+        &header,
         &claims,
-        &EncodingKey::from_secret(state.jwt_secret.as_bytes()),
+        &state.encoding_key,
     )
     .map_err(|e| AppError::Internal(format!("JWT encode error: {e}")))
 }
@@ -378,12 +407,56 @@ pub async fn auth_middleware(
         .strip_prefix("Bearer ")
         .ok_or_else(|| AppError::Unauthorized("Expected Bearer token".into()))?;
 
-    decode::<Claims>(
+    let validation = Validation::new(Algorithm::RS256);
+    let token_data = decode::<Claims>(
         token,
-        &DecodingKey::from_secret(state.jwt_secret.as_bytes()),
-        &Validation::default(),
+        &state.decoding_key,
+        &validation,
     )
     .map_err(|e| AppError::Unauthorized(format!("Invalid token: {e}")))?;
 
+    if !token_data.claims.scopes.contains(&"simulate".to_string()) {
+        return Err(AppError::Unauthorized("Missing required scope 'simulate'".into()));
+    }
+
     Ok(next.run(req).await)
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct JwkSetResponse {
+    pub keys: Vec<JwkResponse>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct JwkResponse {
+    pub kty: String,
+    pub alg: String,
+    pub kid: String,
+    pub n: String,
+    pub e: String,
+    #[serde(rename = "use")]
+    pub use_: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/auth/jwks",
+    responses(
+        (status = 200, description = "JSON Web Key Set", body = JwkSetResponse)
+    ),
+    tag = "Auth"
+)]
+pub async fn jwks_handler(
+    Extension(state): Extension<Arc<AuthState>>,
+) -> Result<Json<JwkSetResponse>, AppError> {
+    Ok(Json(JwkSetResponse {
+        keys: vec![JwkResponse {
+            kty: "RSA".to_string(),
+            alg: "RS256".to_string(),
+            kid: "1".to_string(),
+            n: state.jwk_n.clone(),
+            e: state.jwk_e.clone(),
+            use_: "sig".to_string(),
+        }],
+    }))
 }

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -51,8 +51,8 @@ struct AppConfig {
     /// Primary RPC URL — used as a single-provider fallback when
     /// `RPC_PROVIDERS` is not set.
     soroban_rpc_url: String,
-    /// JWT secret for authentication
-    jwt_secret: String,
+    /// Optional RSA Private Key PEM for RS256 JWTs. If missing, a dev key is generated.
+    jwt_private_key: Option<String>,
     /// Stellar network passphrase
     network_passphrase: String,
     /// Redis URL reserved for the distributed cache migration (issue #65).
@@ -135,7 +135,6 @@ fn load_config() -> Result<AppConfig, ConfigError> {
         .set_default("server_port", 8080)?
         .set_default("rust_log", "info")?
         .set_default("soroban_rpc_url", "https://soroban-testnet.stellar.org")?
-        .set_default("jwt_secret", "dev-secret-change-in-production")?
         .set_default("network_passphrase", "Test SDF Network ; September 2015")?
         .set_default("redis_url", "redis://127.0.0.1:6379")?
         .set_default("rpc_providers", "")?
@@ -945,7 +944,7 @@ async fn fee_analytics(
 #[openapi(
     paths(
         analyze, analyze_wasm, optimize_limits, compare_handler,
-        auth::challenge_handler, auth::verify_handler,
+        auth::challenge_handler, auth::verify_handler, auth::jwks_handler,
         fee_recommend, fee_history, fee_analytics
     ),
     components(schemas(
@@ -954,6 +953,7 @@ async fn fee_analytics(
         CompareApiResponse, RegressionReport, ResourceDelta, RegressionFlag,
         auth::ChallengeRequest, auth::ChallengeResponse,
         auth::VerifyRequest, auth::VerifyResponse,
+        auth::JwkSetResponse, auth::JwkResponse,
         crate::simulation::OptimizationBuffer,
         crate::simulation::SorobanResources,
         FeeRecommendationRequest, FeeRecommendationResponse,
@@ -1164,7 +1164,7 @@ async fn main() {
     tracing::info!("Starting SoroScope API Server...");
 
     let auth_state = Arc::new(auth::AuthState::new(
-        config.jwt_secret.clone(),
+        config.jwt_private_key.clone(),
         None,
         config.network_passphrase.clone(),
     ));
@@ -1283,6 +1283,7 @@ async fn main() {
         .route("/health", get(health_check))
         .route("/auth/challenge", post(auth::challenge_handler))
         .route("/auth/verify", post(auth::verify_handler))
+        .route("/auth/jwks", get(auth::jwks_handler))
         // Fee market routes (public access)
         .route("/fees/recommend", get(fee_recommend))
         .route("/fees/history", get(fee_history))

--- a/package.json
+++ b/package.json
@@ -2,4 +2,5 @@
   "dependencies": {
     "@stellar/stellar-sdk": "^14.6.1"
   }
+
 }


### PR DESCRIPTION
Closes #106

# Backend: JWT-RS256 Migration for API Authentication

## Description
This PR migrates the API authentication logic from simple HS256 tokens to a robust RS256 JWT implementation. This update enhances security by introducing asymmetric key signing, establishes a JSON Web Key Set (JWKS) endpoint for public-key verification, and adds scoped permissions to token claims to control endpoint access.

## Changes Made
* **`core/Cargo.toml`**: 
  * Added the `rsa` crate dependency to handle RSA key processing and generation.
* **`core/src/auth.rs`**: 
  * Updated `encode` and `decode` routines to utilize `jsonwebtoken::Algorithm::RS256`.
  * Modified `AuthState` to parse an RSA Private Key PEM provided via config. For local development continuity, it safely falls back to generating an ephemeral 2048-bit keypair on startup if the key is missing.
  * Added a `scopes: Vec<String>` field to the JWT `Claims` payload.
  * Updated `verify_challenge_envelope` to issue tokens containing the `simulate` scope.
  * Updated `auth_middleware` to explicitly enforce the presence of the `simulate` scope for protected routes.
  * Implemented `jwks_handler` to securely expose the public key's Modulus (`n`) and Exponent (`e`) in standard JWKS format.
* **`core/src/main.rs`**: 
  * Replaced the obsolete `jwt_secret` configuration property with `jwt_private_key: Option<String>`.
  * Registered the new `GET /auth/jwks` route in the Axum router.

## Testing Instructions
1. Start the server locally via `cargo run -p soroscope-core`.
2. Verify the public key is properly exposed by making a `GET` request to `http://localhost:8080/auth/jwks`.
3. Complete the SEP-10 challenge flow (`POST /auth/challenge` -> `POST /auth/verify`) to receive a newly minted RS256 JWT.
4. Verify the scoped permissions by ensuring requests to protected endpoints (e.g., `/analyze`) succeed when providing the new Bearer token in the `Authorization` header.

