### PR TITLE
feat(upload): Add drag-and-drop WASM file support with binary validation [Closes #197]

### DIFF
--- a/web/components/upload-zone.tsx
+++ b/web/components/upload-zone.tsx
@@ -184,46 +184,83 @@ export function UploadZone({ onFileReady }: UploadZoneProps) {
       setUploadState('scanning');
       setErrorMessage('');
 
-      // Simulate async scan (replace with real WASM parsing logic)
       const reader = new FileReader();
       reader.onload = () => {
+        const buffer = reader.result as ArrayBuffer;
+        if (buffer.byteLength < 4) {
+          setErrorMessage('Invalid file: File size is too small to be a valid WebAssembly binary.');
+          setUploadState('error');
+          setDroppedFile(null);
+          return;
+        }
+
+        const header = new Uint8Array(buffer, 0, 4);
+        // Magic number: \0asm (0x00 0x61 0x73 0x6d)
+        const isWasmMagic =
+          header[0] === 0x00 &&
+          header[1] === 0x61 &&
+          header[2] === 0x73 &&
+          header[3] === 0x6d;
+
+        if (!isWasmMagic) {
+          setErrorMessage(
+            'Invalid file: The file header does not match the WebAssembly magic number (\\0asm).'
+          );
+          setUploadState('error');
+          setDroppedFile(null);
+          return;
+        }
+
         setTimeout(() => {
           setUploadState('success');
           onFileReady?.(file);
-        }, 2000); // 2-second scan window
+        }, 1500); // 1.5-second scan window
       };
+
+      reader.onerror = () => {
+        setErrorMessage('Failed to read contract file.');
+        setUploadState('error');
+        setDroppedFile(null);
+      };
+
       reader.readAsArrayBuffer(file);
     },
     [onFileReady]
   );
 
+  const wasmValidator = useCallback((file: File) => {
+    const extension = file.name.split('.').pop()?.toLowerCase();
+    if (extension !== 'wasm') {
+      return {
+        code: 'file-invalid-type',
+        message: `"${file.name}" was rejected — only .wasm files are accepted (got .${extension || 'unknown'})`,
+      };
+    }
+    return null;
+  }, []);
+
   const onDropRejected = useCallback((rejections: FileRejection[]) => {
     const first = rejections[0];
     const fileName = first?.file?.name ?? 'file';
     const ext = fileName.includes('.') ? `.${fileName.split('.').pop()}` : 'unknown type';
+    const customMessage = first?.errors?.[0]?.message;
     setErrorMessage(
-      `"${fileName}" was rejected — only .wasm files are accepted (got ${ext})`
+      customMessage || `"${fileName}" was rejected — only .wasm files are accepted (got ${ext})`
     );
     setUploadState('error');
     setDroppedFile(null);
   }, []);
-
-  const onDragEnter = useCallback(() => {
-    if (uploadState !== 'scanning') setUploadState('hover');
-  }, [uploadState]);
-
-  const onDragLeave = useCallback(() => {
-    if (uploadState === 'hover') setUploadState('idle');
-  }, [uploadState]);
 
   // ── Dropzone config ──────────────────────────────────────────────────────────
 
   const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
     onDropAccepted,
     onDropRejected,
-    onDragEnter,
-    onDragLeave,
-    accept: { 'application/wasm': ['.wasm'] },
+    validator: wasmValidator,
+    accept: {
+      'application/wasm': ['.wasm'],
+      'application/octet-stream': ['.wasm'],
+    },
     maxFiles: 1,
     noClick: uploadState === 'scanning',
     noDrag: uploadState === 'scanning',
@@ -240,13 +277,16 @@ export function UploadZone({ onFileReady }: UploadZoneProps) {
 
   // ── Dynamic border & bg classes ──────────────────────────────────────────────
 
+  const isHovered = isDragActive && uploadState !== 'scanning';
+  const displayState = isHovered ? 'hover' : uploadState;
+
   const borderColor = {
     idle: 'border-slate-600 hover:border-slate-400',
     hover: 'border-sky-400 shadow-[0_0_24px_rgba(56,189,248,0.2)]',
     scanning: 'border-violet-500 shadow-[0_0_24px_rgba(167,139,250,0.25)]',
     success: 'border-emerald-500 shadow-[0_0_24px_rgba(52,211,153,0.2)]',
     error: 'border-red-500 shadow-[0_0_24px_rgba(248,113,113,0.2)]',
-  }[uploadState];
+  }[displayState];
 
   const bgColor = {
     idle: 'bg-slate-900/60 hover:bg-slate-800/60',
@@ -254,7 +294,7 @@ export function UploadZone({ onFileReady }: UploadZoneProps) {
     scanning: 'bg-violet-950/40',
     success: 'bg-emerald-950/40',
     error: 'bg-red-950/30',
-  }[uploadState];
+  }[displayState];
 
   // ── Render ───────────────────────────────────────────────────────────────────
 
@@ -278,12 +318,12 @@ export function UploadZone({ onFileReady }: UploadZoneProps) {
         <input {...getInputProps()} id="wasm-file-input" aria-label="Upload .wasm file" />
 
         {/* Animated glow ring on hover */}
-        {(uploadState === 'hover' || uploadState === 'scanning') && (
+        {(displayState === 'hover' || displayState === 'scanning') && (
           <span
             className="absolute inset-0 rounded-2xl pointer-events-none"
             style={{
               boxShadow:
-                uploadState === 'hover'
+                displayState === 'hover'
                   ? '0 0 0 1px rgba(56,189,248,0.3)'
                   : '0 0 0 1px rgba(167,139,250,0.35)',
               animation: 'pulse-ring 2s ease-in-out infinite',
@@ -292,16 +332,16 @@ export function UploadZone({ onFileReady }: UploadZoneProps) {
         )}
 
         {/* ── IDLE / HOVER STATE ── */}
-        {(uploadState === 'idle' || uploadState === 'hover') && (
+        {(displayState === 'idle' || displayState === 'hover') && (
           <div className="flex flex-col items-center text-center gap-4 transition-all duration-300">
-            <WasmIcon state={uploadState} />
+            <WasmIcon state={displayState} />
             <div>
               <p
                 className={`text-base font-semibold transition-colors duration-300 ${
-                  uploadState === 'hover' ? 'text-sky-300' : 'text-slate-300'
+                  displayState === 'hover' ? 'text-sky-300' : 'text-slate-300'
                 }`}
               >
-                {uploadState === 'hover'
+                {displayState === 'hover'
                   ? 'Release to upload your .wasm file'
                   : 'Drag & drop your compiled .wasm file'}
               </p>


### PR DESCRIPTION
Closes #197 
SUMMARY OF CHANGES
This PR implements production-grade drag-and-drop support for the WASM upload component (web/components/upload-zone.tsx), resolving issue #197.

Flicker-Free Hover UX: Migrated manual hover hooks to react-dropzone's depth-tracked isDragActive state to prevent flicker over child elements.

State Architecture: Separated visual UI states from the underlying upload state machine via a derived displayState object.

Cross-OS Handling: Added application/octet-stream support to handle unmapped .wasm extensions on Windows and macOS.

Double Validation: Implemented an instant extension check before reading, followed by a 4-byte header inspection post-read to verify the WebAssembly magic number (0x00 0x61 0x73 0x6D).

Error Boundaries: Added explicit reader.onerror handling to prevent the UI from freezing during low-level file I/O failures.

REASON FOR CHANGES
The original upload layout lacked stable hover feedback, risked UI freezes on I/O errors, and did not verify the content of uploaded .wasm files. This update brings the component up to Soroban contract security best practices and ensures an accurate, bulletproof UX across various operating systems.