### PR TITLE
emergency guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,7 +3555,7 @@ dependencies = [
 name = "soroban-liquidity-pool-factory-contract"
 version = "0.1.0"
 dependencies = [
- "liquidity_pool",
+ "emergency_guard",
  "soroban-sdk",
  "soroban-token-contract",
 ]

--- a/contracts/emergency_guard/src/lib.rs
+++ b/contracts/emergency_guard/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, log, Address, Env, Error, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, log, Address, Env, String, Vec,
+};
 
 /// Granular pause types using bitmask for efficient storage
 /// Each bit represents a different pausable operation
@@ -72,7 +74,51 @@ pub enum GuardError {
     AlreadyInitialized = 6,
 }
 
+/// Standardized event actions emitted by every successful guard action.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum EmergencyGuardAction {
+    Initialized,
+    PauseSet,
+    EmergencyPause,
+    Resume,
+    AdminAdded,
+    AdminRemoved,
+}
 
+/// Standardized event payload for EmergencyGuard administrative actions.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmergencyGuardEvent {
+    pub action: EmergencyGuardAction,
+    pub admin: Option<Address>,
+    pub operation: u32,
+    pub paused: bool,
+    pub threshold: u32,
+    pub admin_count: u32,
+    pub approver_count: u32,
+}
+
+fn action_topic(env: &Env, action: EmergencyGuardAction) -> String {
+    match action {
+        EmergencyGuardAction::Initialized => String::from_str(env, "initialized"),
+        EmergencyGuardAction::PauseSet => String::from_str(env, "pause_set"),
+        EmergencyGuardAction::EmergencyPause => String::from_str(env, "emergency_pause"),
+        EmergencyGuardAction::Resume => String::from_str(env, "resume"),
+        EmergencyGuardAction::AdminAdded => String::from_str(env, "admin_added"),
+        EmergencyGuardAction::AdminRemoved => String::from_str(env, "admin_removed"),
+    }
+}
+
+fn emit_guard_event(env: &Env, event: EmergencyGuardEvent) {
+    env.events().publish(
+        (
+            String::from_str(env, "EmergencyGuard"),
+            action_topic(env, event.action),
+        ),
+        event,
+    );
+}
 
 /// Result type for guard operations
 // Result type for guard operations replaced inline
@@ -142,6 +188,19 @@ impl EmergencyGuard {
             .instance()
             .set(&DataKey::PauseState, &PauseType::new(0));
 
+        emit_guard_event(
+            &env,
+            EmergencyGuardEvent {
+                action: EmergencyGuardAction::Initialized,
+                admin: None,
+                operation: 0,
+                paused: false,
+                threshold,
+                admin_count: admins.len(),
+                approver_count: 0,
+            },
+        );
+
         Ok(())
     }
 
@@ -157,7 +216,12 @@ impl EmergencyGuard {
     }
 
     /// Set pause state for a specific operation (any single admin can do this)
-    pub fn set_pause(env: Env, admin: Address, operation: u32, paused: bool) -> Result<(), GuardError> {
+    pub fn set_pause(
+        env: Env,
+        admin: Address,
+        operation: u32,
+        paused: bool,
+    ) -> Result<(), GuardError> {
         admin.require_auth();
 
         // Check if caller is admin
@@ -176,6 +240,18 @@ impl EmergencyGuard {
             .instance()
             .set(&DataKey::PauseState, &pause_state);
 
+        emit_guard_event(
+            &env,
+            EmergencyGuardEvent {
+                action: EmergencyGuardAction::PauseSet,
+                admin: Some(admin),
+                operation,
+                paused,
+                threshold: Self::get_threshold(env.clone()),
+                admin_count: Self::get_admins(env.clone()).len(),
+                approver_count: 1,
+            },
+        );
         log!(
             &env,
             "Pause state updated: op={}, paused={}",
@@ -196,6 +272,18 @@ impl EmergencyGuard {
             .instance()
             .set(&DataKey::PauseState, &pause_state);
 
+        emit_guard_event(
+            &env,
+            EmergencyGuardEvent {
+                action: EmergencyGuardAction::EmergencyPause,
+                admin: None,
+                operation: u32::MAX,
+                paused: true,
+                threshold: Self::get_threshold(env.clone()),
+                admin_count: Self::get_admins(env.clone()).len(),
+                approver_count: approvers.len(),
+            },
+        );
         log!(&env, "Emergency pause all activated");
         Ok(())
     }
@@ -209,18 +297,46 @@ impl EmergencyGuard {
             .instance()
             .set(&DataKey::PauseState, &pause_state);
 
+        emit_guard_event(
+            &env,
+            EmergencyGuardEvent {
+                action: EmergencyGuardAction::Resume,
+                admin: None,
+                operation: u32::MAX,
+                paused: false,
+                threshold: Self::get_threshold(env.clone()),
+                admin_count: Self::get_admins(env.clone()).len(),
+                approver_count: approvers.len(),
+            },
+        );
         log!(&env, "Resume all activated");
         Ok(())
     }
 
     /// Add new admin (multi-sig required)
-    pub fn add_admin(env: Env, approvers: Vec<Address>, new_admin: Address) -> Result<(), GuardError> {
+    pub fn add_admin(
+        env: Env,
+        approvers: Vec<Address>,
+        new_admin: Address,
+    ) -> Result<(), GuardError> {
         Self::check_multi_sig(&env, &approvers)?;
 
         let mut admins = Self::get_admins(env.clone());
         if !admins.iter().any(|a| a == new_admin) {
             admins.push_back(new_admin.clone());
             env.storage().instance().set(&DataKey::Admins, &admins);
+            emit_guard_event(
+                &env,
+                EmergencyGuardEvent {
+                    action: EmergencyGuardAction::AdminAdded,
+                    admin: Some(new_admin.clone()),
+                    operation: 0,
+                    paused: false,
+                    threshold: Self::get_threshold(env.clone()),
+                    admin_count: admins.len(),
+                    approver_count: approvers.len(),
+                },
+            );
             log!(&env, "Admin added: {}", new_admin);
         }
 
@@ -228,7 +344,11 @@ impl EmergencyGuard {
     }
 
     /// Remove admin (multi-sig required)
-    pub fn remove_admin(env: Env, approvers: Vec<Address>, admin: Address) -> Result<(), GuardError> {
+    pub fn remove_admin(
+        env: Env,
+        approvers: Vec<Address>,
+        admin: Address,
+    ) -> Result<(), GuardError> {
         Self::check_multi_sig(&env, &approvers)?;
 
         let admins = Self::get_admins(env.clone());
@@ -253,6 +373,18 @@ impl EmergencyGuard {
         }
 
         env.storage().instance().set(&DataKey::Admins, &new_admins);
+        emit_guard_event(
+            &env,
+            EmergencyGuardEvent {
+                action: EmergencyGuardAction::AdminRemoved,
+                admin: Some(admin.clone()),
+                operation: 0,
+                paused: false,
+                threshold,
+                admin_count: new_admins.len(),
+                approver_count: approvers.len(),
+            },
+        );
         log!(&env, "Admin removed: {}", admin);
         Ok(())
     }

--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -8,12 +8,11 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+emergency_guard = { path = "../emergency_guard" }
 soroban-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
-# We need the pool contract code for integration tests
-liquidity-pool-contract = { package = "liquidity_pool", path = "../liquidity_pool" }
 token-contract = { package = "soroban-token-contract", path = "../token" }
 
 [features]

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
+use emergency_guard::{EmergencyGuard, GuardError, PauseType};
 use soroban_sdk::{
-    contract, contractimpl, contracttype, xdr::ToXdr, Address, BytesN, Env, IntoVal,
+    contract, contractimpl, contracttype, xdr::ToXdr, Address, BytesN, Env, IntoVal, Vec,
 };
 
 /// Storage key for pair registry.
@@ -25,6 +26,10 @@ impl LiquidityPoolFactory {
         token_b: Address,
         wasm_hash: BytesN<32>,
     ) -> Address {
+        if EmergencyGuard::is_paused(env.clone(), PauseType::MINT) {
+            panic!("Factory pair creation is paused");
+        }
+
         let (token_0, token_1) = if token_a < token_b {
             (token_a, token_b)
         } else {
@@ -81,6 +86,58 @@ impl LiquidityPoolFactory {
         env.storage()
             .instance()
             .get(&DataKey::Pair(token_0, token_1))
+    }
+
+    /// Initialize the factory's emergency guard.
+    pub fn initialize_guard(
+        env: Env,
+        admins: Vec<Address>,
+        threshold: u32,
+    ) -> Result<(), GuardError> {
+        EmergencyGuard::initialize(env, admins, threshold)
+    }
+
+    /// Admin-only: pause or unpause a factory operation.
+    pub fn set_guard_pause(
+        env: Env,
+        admin: Address,
+        operation: u32,
+        paused: bool,
+    ) -> Result<(), GuardError> {
+        EmergencyGuard::set_pause(env, admin, operation, paused)
+    }
+
+    /// Multi-sig: pause all guarded factory operations.
+    pub fn emergency_guard_pause(env: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
+        EmergencyGuard::emergency_pause(env, approvers)
+    }
+
+    /// Multi-sig: resume all guarded factory operations.
+    pub fn resume_guard(env: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
+        EmergencyGuard::resume(env, approvers)
+    }
+
+    /// Multi-sig: add a factory guard admin.
+    pub fn add_guard_admin(
+        env: Env,
+        approvers: Vec<Address>,
+        new_admin: Address,
+    ) -> Result<(), GuardError> {
+        EmergencyGuard::add_admin(env, approvers, new_admin)
+    }
+
+    /// Multi-sig: remove a factory guard admin.
+    pub fn remove_guard_admin(
+        env: Env,
+        approvers: Vec<Address>,
+        admin: Address,
+    ) -> Result<(), GuardError> {
+        EmergencyGuard::remove_admin(env, approvers, admin)
+    }
+
+    /// Returns whether a factory operation is currently paused.
+    pub fn is_guard_paused(env: Env, operation: u32) -> bool {
+        EmergencyGuard::is_paused(env, operation)
     }
 }
 

--- a/contracts/factory/src/test.rs
+++ b/contracts/factory/src/test.rs
@@ -2,7 +2,12 @@
 extern crate std;
 use super::*;
 
-use soroban_sdk::{testutils::Address as _, Env};
+use emergency_guard::{EmergencyGuardAction, EmergencyGuardEvent, PauseType};
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    vec, Address, Env, String as SorobanString, TryIntoVal,
+};
+use std::vec::Vec;
 // use soroban_sdk::{token, BytesN};
 
 // Import the LiquidityPool contract to get its WASM bytes for testing
@@ -88,3 +93,191 @@ fn test_create_pair() {
 // let pool_address = factory_client.create_pair(&token_a, &token_b, &pool_hash);
 // assert!(pool_address != factory_id);
 */
+
+fn guard_events(env: &Env, contract_id: &Address, action: &str) -> Vec<EmergencyGuardEvent> {
+    let guard_topic = SorobanString::from_str(env, "EmergencyGuard");
+    let action_topic = SorobanString::from_str(env, action);
+
+    env.events()
+        .all()
+        .iter()
+        .filter_map(|(event_contract, topics, data)| {
+            if event_contract != *contract_id || topics.len() != 2 {
+                return None;
+            }
+
+            let topic_guard: SorobanString = topics.get(0)?.try_into_val(env).ok()?;
+            let topic_action: SorobanString = topics.get(1)?.try_into_val(env).ok()?;
+
+            if topic_guard == guard_topic && topic_action == action_topic {
+                data.try_into_val(env).ok()
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn setup_guard(
+    env: &Env,
+) -> (
+    Address,
+    LiquidityPoolFactoryClient<'_>,
+    Address,
+    Address,
+    Address,
+) {
+    env.mock_all_auths();
+    let factory_id = env.register(LiquidityPoolFactory, ());
+    let factory_client = LiquidityPoolFactoryClient::new(env, &factory_id);
+    let admin1 = Address::generate(env);
+    let admin2 = Address::generate(env);
+    let admin3 = Address::generate(env);
+    let admins = vec![env, admin1.clone(), admin2.clone(), admin3.clone()];
+
+    factory_client.initialize_guard(&admins, &2);
+
+    (factory_id, factory_client, admin1, admin2, admin3)
+}
+
+#[test]
+fn test_initialize_guard_emits_standard_event() {
+    let env = Env::default();
+    let (factory_id, _client, _admin1, _admin2, _admin3) = setup_guard(&env);
+
+    let events = guard_events(&env, &factory_id, "initialized");
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0],
+        EmergencyGuardEvent {
+            action: EmergencyGuardAction::Initialized,
+            admin: None,
+            operation: 0,
+            paused: false,
+            threshold: 2,
+            admin_count: 3,
+            approver_count: 0,
+        }
+    );
+}
+
+#[test]
+fn test_set_guard_pause_emits_standard_events() {
+    let env = Env::default();
+    let (factory_id, client, admin1, _admin2, _admin3) = setup_guard(&env);
+
+    client.set_guard_pause(&admin1, &PauseType::MINT, &true);
+    let events = guard_events(&env, &factory_id, "pause_set");
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0],
+        EmergencyGuardEvent {
+            action: EmergencyGuardAction::PauseSet,
+            admin: Some(admin1.clone()),
+            operation: PauseType::MINT,
+            paused: true,
+            threshold: 2,
+            admin_count: 3,
+            approver_count: 1,
+        }
+    );
+
+    assert!(client.is_guard_paused(&PauseType::MINT));
+
+    client.set_guard_pause(&admin1, &PauseType::MINT, &false);
+    let events = guard_events(&env, &factory_id, "pause_set");
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0],
+        EmergencyGuardEvent {
+            action: EmergencyGuardAction::PauseSet,
+            admin: Some(admin1),
+            operation: PauseType::MINT,
+            paused: false,
+            threshold: 2,
+            admin_count: 3,
+            approver_count: 1,
+        }
+    );
+}
+
+#[test]
+fn test_emergency_pause_and_resume_emit_standard_events() {
+    let env = Env::default();
+    let (factory_id, client, admin1, admin2, _admin3) = setup_guard(&env);
+    let approvers = vec![&env, admin1, admin2];
+
+    client.emergency_guard_pause(&approvers);
+    let emergency_events = guard_events(&env, &factory_id, "emergency_pause");
+    assert_eq!(emergency_events.len(), 1);
+    assert_eq!(
+        emergency_events[0],
+        EmergencyGuardEvent {
+            action: EmergencyGuardAction::EmergencyPause,
+            admin: None,
+            operation: u32::MAX,
+            paused: true,
+            threshold: 2,
+            admin_count: 3,
+            approver_count: 2,
+        }
+    );
+    assert!(client.is_guard_paused(&PauseType::MINT));
+
+    client.resume_guard(&approvers);
+    let resume_events = guard_events(&env, &factory_id, "resume");
+    assert_eq!(resume_events.len(), 1);
+    assert_eq!(
+        resume_events[0],
+        EmergencyGuardEvent {
+            action: EmergencyGuardAction::Resume,
+            admin: None,
+            operation: u32::MAX,
+            paused: false,
+            threshold: 2,
+            admin_count: 3,
+            approver_count: 2,
+        }
+    );
+    assert!(!client.is_guard_paused(&PauseType::MINT));
+}
+
+#[test]
+fn test_admin_guard_actions_emit_standard_events() {
+    let env = Env::default();
+    let (factory_id, client, admin1, admin2, admin3) = setup_guard(&env);
+    let approvers = vec![&env, admin1, admin2];
+    let admin4 = Address::generate(&env);
+
+    client.add_guard_admin(&approvers, &admin4);
+    let added_events = guard_events(&env, &factory_id, "admin_added");
+    assert_eq!(added_events.len(), 1);
+    assert_eq!(
+        added_events[0],
+        EmergencyGuardEvent {
+            action: EmergencyGuardAction::AdminAdded,
+            admin: Some(admin4),
+            operation: 0,
+            paused: false,
+            threshold: 2,
+            admin_count: 4,
+            approver_count: 2,
+        }
+    );
+
+    client.remove_guard_admin(&approvers, &admin3);
+    let removed_events = guard_events(&env, &factory_id, "admin_removed");
+    assert_eq!(removed_events.len(), 1);
+    assert_eq!(
+        removed_events[0],
+        EmergencyGuardEvent {
+            action: EmergencyGuardAction::AdminRemoved,
+            admin: Some(admin3),
+            operation: 0,
+            paused: false,
+            threshold: 2,
+            admin_count: 3,
+            approver_count: 2,
+        }
+    );
+}


### PR DESCRIPTION
Closes #240 
Implemented factory guard event validation.
What changed:
Added standardized EmergencyGuardEvent + EmergencyGuardAction and emit logic in contracts/emergency_guard/src/lib.rs (line 77).
Added factory guard action wrappers and guarded pair creation pause check in contracts/factory/src/lib.rs (line 91).
Added focused factory tests validating event topics and payloads for initialize, pause/unpause, emergency pause, resume, add admin, and remove admin in contracts/factory/src/test.rs (line 97).
Updated factory deps to use emergency_guard directly and removed the unused liquidity_pool dev-dependency that was pulling in broken unrelated code.
Verification:
cargo test -p soroban-liquidity-pool-factory-contract passes: 5 tests.
cargo test --manifest-path contracts/emergency_guard/Cargo.toml --lib passes.
Full contracts/emergency_guard manifest test is still blocked by an existing stale example importing DefaultEmergencyGuard.