### PR TITLE
feat(web): Setup type-safe API client and integrate `/analyze` backend endpoint (#195)

### DIFF
--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,0 +1,151 @@
+/**
+ * SoroScope API Client
+ * Production-grade, lightweight, type-safe API client configuration using native Fetch API.
+ * Integrates Next.js frontend to the Rust Axum backend.
+ */
+
+export interface ApiRequestOptions extends RequestInit {
+  params?: Record<string, string>;
+  token?: string;
+}
+
+export class ApiError extends Error {
+  status: number;
+  statusText: string;
+  body: any;
+
+  constructor(status: number, statusText: string, body: any) {
+    super(`API Error ${status}: ${body?.message || statusText}`);
+    this.name = 'ApiError';
+    this.status = status;
+    this.statusText = statusText;
+    this.body = body;
+  }
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+
+async function request<T>(endpoint: string, options: ApiRequestOptions = {}): Promise<T> {
+  const { params, token, headers, ...customConfig } = options;
+  
+  // Build full query string if params are provided
+  let queryString = '';
+  if (params) {
+    const searchParams = new URLSearchParams();
+    Object.entries(params).forEach(([key, val]) => {
+      if (val !== undefined && val !== null) {
+        searchParams.append(key, val);
+      }
+    });
+    queryString = `?${searchParams.toString()}`;
+  }
+
+  const fullUrl = `${BASE_URL}${endpoint}${queryString}`;
+
+  const defaultHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  };
+
+  if (token) {
+    defaultHeaders['Authorization'] = `Bearer ${token}`;
+  }
+
+  const config: RequestInit = {
+    method: options.method || 'GET',
+    headers: {
+      ...defaultHeaders,
+      ...headers,
+    },
+    ...customConfig,
+  };
+
+  try {
+    const response = await fetch(fullUrl, config);
+    
+    let responseData: any = null;
+    const contentType = response.headers.get('content-type');
+    if (contentType && contentType.includes('application/json')) {
+      responseData = await response.json();
+    } else {
+      responseData = await response.text();
+    }
+
+    if (!response.ok) {
+      throw new ApiError(response.status, response.statusText, responseData);
+    }
+
+    return responseData as T;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+    // Network errors or aborts
+    throw new Error(error instanceof Error ? error.message : 'Network request failed');
+  }
+}
+
+// Typed base request methods
+export const apiClient = {
+  get<T>(endpoint: string, options?: ApiRequestOptions): Promise<T> {
+    return request<T>(endpoint, { ...options, method: 'GET' });
+  },
+
+  post<T>(endpoint: string, body?: any, options?: ApiRequestOptions): Promise<T> {
+    return request<T>(endpoint, {
+      ...options,
+      method: 'POST',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  },
+
+  put<T>(endpoint: string, body?: any, options?: ApiRequestOptions): Promise<T> {
+    return request<T>(endpoint, {
+      ...options,
+      method: 'PUT',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  },
+
+  delete<T>(endpoint: string, options?: ApiRequestOptions): Promise<T> {
+    return request<T>(endpoint, { ...options, method: 'DELETE' });
+  },
+};
+
+// Domain-specific Analyze Service endpoints
+export interface AnalyzeRequest {
+  contract_id: string;
+  function_name: string;
+  args?: string[];
+  ledger_overrides?: Record<string, string>;
+  protocol_version?: number;
+  enable_experimental?: boolean;
+}
+
+export interface AnalyzeWasmRequest {
+  wasm_bytes: string;
+  function_name: string;
+  args?: string[];
+  protocol_version?: number;
+  enable_experimental?: boolean;
+}
+
+export const analyzeService = {
+  /**
+   * Profiling a contract invocation by ID
+   * @param req The contract analysis request payload
+   * @param token JWT authorization token (optional)
+   */
+  async analyze(req: AnalyzeRequest, token?: string): Promise<any> {
+    return apiClient.post<any>('/analyze', req, { token });
+  },
+
+  /**
+   * Analyze custom WASM file binary bytes
+   * @param req The WASM bytes analysis request payload
+   * @param token JWT authorization token (optional)
+   */
+  async analyzeWasm(req: AnalyzeWasmRequest, token?: string): Promise<any> {
+    return apiClient.post<any>('/analyze/wasm', req, { token });
+  },
+};

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -9,6 +9,7 @@ import { ContractInteraction } from '../components/ContractInteraction';
 import { MOCK_CONTRACT_FUNCTIONS, generateMockResult, generateMockResourceCost } from '../lib/sorobantypes';
 import type { ContractFunction, InvocationResult } from '../lib/sorobantypes';
 import { UploadZone } from '../components/upload-zone';
+import { analyzeService } from '../lib/api';
 
 export default function Home() {
   const [contractId, setContractId] = useState('CAEZJVJ4N7P7GRUVD5NG5LYYH23AQHJUKQEUHW54LR5PGQX3V7FXD7Q');
@@ -21,20 +22,7 @@ export default function Home() {
   const handleSimulate = async (inputs: Record<string, any>) => {
     setLoading(true);
     try {
-      const response = await fetch('http://localhost:8080/analyze', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          contract_id: contractId,
-          function_name: selectedFunction.name,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`Backend error: ${response.statusText}`);
-      }
-
-      const report = await response.json();
+      const report = await analyzeService.analyze({ contract_id: contractId, function_name: selectedFunction.name });
 
       const result: InvocationResult = {
         id: Math.random().toString(36).substring(7),


### PR DESCRIPTION
closes #195 
## Summary of Changes
- **Type-Safe API Client (`web/lib/api.ts`):** 
  - Implemented a production-grade, lightweight REST API client wrapping the native Fetch API.
  - Added full type safety with TypeScript interfaces matching the Rust Axum backend's structs (`AnalyzeRequest` and `AnalyzeWasmRequest`).
  - Added robust error handling through a custom `ApiError` class to capture HTTP status codes and backend error messages.
  - Exported standard client methods (`get`, `post`, `put`, `delete`) and a domain-specific `analyzeService`.
- **UI Page Integration (`web/pages/index.tsx`):**
  - Integrated `analyzeService.analyze` into `handleSimulate` to replace the inline, non-type-safe fetch call.
  - Ensured correct request payload mapping with fields corresponding to the backend's expectations.
  - 
## Reason for the Changes
These changes resolve Issue #195 by establishing the core API infrastructure for the Next.js frontend to communicate with the Rust backend CLI. This clean, modular architecture makes future endpoint integrations straightforward, handles backend error states gracefullly, and ensures full type alignment between frontend requests and Rust deserializer structs.