### PR TITLE
refactor(factory): align admin controls with EmergencyGuard

### DIFF
--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "22.0.0"
+emergency_guard = { path = "../emergency_guard" }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, xdr::ToXdr, Address, BytesN, Env, IntoVal,
+    contract, contractimpl, contracttype, xdr::ToXdr, Address, BytesN, Env, IntoVal, Vec,
 };
+use emergency_guard::{EmergencyGuard, GuardError};
 
 /// Storage key for pair registry.
 /// Stored in **instance** storage because the factory is a singleton contract
@@ -18,6 +19,44 @@ pub struct LiquidityPoolFactory;
 
 #[contractimpl]
 impl LiquidityPoolFactory {
+    /// Initializes the factory admin committee using the shared EmergencyGuard storage.
+    pub fn initialize(env: Env, admins: Vec<Address>, threshold: u32) -> Result<(), GuardError> {
+        EmergencyGuard::initialize(env, admins, threshold)
+    }
+
+    /// Add a new admin using the shared multi-signature approval flow.
+    pub fn add_admin(
+        env: Env,
+        approvers: Vec<Address>,
+        new_admin: Address,
+    ) -> Result<(), GuardError> {
+        EmergencyGuard::add_admin(env, approvers, new_admin)
+    }
+
+    /// Remove an admin using the shared multi-signature approval flow.
+    pub fn remove_admin(
+        env: Env,
+        approvers: Vec<Address>,
+        admin: Address,
+    ) -> Result<(), GuardError> {
+        EmergencyGuard::remove_admin(env, approvers, admin)
+    }
+
+    /// Returns the currently configured factory admins.
+    pub fn get_admins(env: Env) -> Vec<Address> {
+        EmergencyGuard::get_admins(env)
+    }
+
+    /// Returns the required multi-signature threshold.
+    pub fn get_threshold(env: Env) -> u32 {
+        EmergencyGuard::get_threshold(env)
+    }
+
+    /// Checks whether an address is currently authorized as a factory admin.
+    pub fn is_admin(env: Env, addr: Address) -> bool {
+        EmergencyGuard::is_admin(&env, &addr)
+    }
+
     /// Deploys a new Liquidity Pool contract for a unique pair of tokens.
     pub fn create_pair(
         env: Env,

--- a/contracts/factory/src/test.rs
+++ b/contracts/factory/src/test.rs
@@ -2,7 +2,7 @@
 extern crate std;
 use super::*;
 
-use soroban_sdk::{testutils::Address as _, Env};
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
 
 // Import the Liquidity Pool WASM for integration testing.
 // This requires running `cargo build --target wasm32-unknown-unknown --release`
@@ -32,6 +32,59 @@ fn test_initialization() {
     // Pair should not exist yet
     let result = factory_client.get_pair(&token_a, &token_b);
     assert_eq!(result, None);
+}
+
+#[test]
+fn test_guard_admin_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let factory_id = env.register(LiquidityPoolFactory, ());
+    let factory_client = LiquidityPoolFactoryClient::new(&env, &factory_id);
+
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    let admins = vec![&env, admin1.clone(), admin2.clone()];
+
+    assert_eq!(factory_client.initialize(&admins, &2), Ok(()));
+    assert_eq!(factory_client.get_threshold(), 2);
+    assert_eq!(factory_client.get_admins().len(), 2);
+    assert!(factory_client.is_admin(&admin1));
+    assert!(factory_client.is_admin(&admin2));
+}
+
+#[test]
+fn test_guard_admin_threshold_checks() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let factory_id = env.register(LiquidityPoolFactory, ());
+    let factory_client = LiquidityPoolFactoryClient::new(&env, &factory_id);
+
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let admins = vec![&env, admin1.clone(), admin2.clone()];
+
+    assert_eq!(factory_client.initialize(&admins, &2), Ok(()));
+
+    let single_approver = vec![&env, admin1.clone()];
+    assert_eq!(
+        factory_client.add_admin(&single_approver, &new_admin),
+        Err(GuardError::InsufficientSignatures)
+    );
+
+    let full_approvals = vec![&env, admin1.clone(), admin2.clone()];
+    assert_eq!(factory_client.add_admin(&full_approvals, &new_admin), Ok(()));
+    assert!(factory_client.is_admin(&new_admin));
+
+    assert_eq!(
+        factory_client.remove_admin(&single_approver, &new_admin),
+        Err(GuardError::InsufficientSignatures)
+    );
+
+    assert_eq!(factory_client.remove_admin(&full_approvals, &new_admin), Ok(()));
+    assert!(!factory_client.is_admin(&new_admin));
 }
 
 #[test]


### PR DESCRIPTION
Closes #233

## Summary
- Added EmergencyGuard-backed factory admin initialization and multi-sig admin management
- Exposed admin/threshold queries on the factory contract
- Added tests covering initialization, threshold enforcement, and admin add/remove flows

## Validation
- `get_errors` clean for touched factory files
- `git diff --check` clean
- Rust `cargo test` could not be run in this container because `cargo` is unavailable