### PR TITLE
Feat: FE implemented file size validation for WASM uploads

### DIFF
--- a/web/components/upload-zone.tsx
+++ b/web/components/upload-zone.tsx
@@ -20,6 +20,14 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
 }
 
+const MAX_WASM_SIZE = 5 * 1024 * 1024; // 5 MB — Soroban contract size ceiling
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d]; // \0asm
+
+function hasWasmMagic(buffer: ArrayBuffer): boolean {
+  const bytes = new Uint8Array(buffer, 0, 4);
+  return WASM_MAGIC.every((b, i) => bytes[i] === b);
+}
+
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
 /** Animated WASM hex-grid icon */
@@ -184,13 +192,19 @@ export function UploadZone({ onFileReady }: UploadZoneProps) {
       setUploadState('scanning');
       setErrorMessage('');
 
-      // Simulate async scan (replace with real WASM parsing logic)
       const reader = new FileReader();
       reader.onload = () => {
+        const buffer = reader.result as ArrayBuffer;
+        if (!hasWasmMagic(buffer)) {
+          setErrorMessage(`"${file.name}" is not a valid WASM binary (magic bytes mismatch)`);
+          setUploadState('error');
+          setDroppedFile(null);
+          return;
+        }
         setTimeout(() => {
           setUploadState('success');
           onFileReady?.(file);
-        }, 2000); // 2-second scan window
+        }, 2000);
       };
       reader.readAsArrayBuffer(file);
     },
@@ -200,9 +214,12 @@ export function UploadZone({ onFileReady }: UploadZoneProps) {
   const onDropRejected = useCallback((rejections: FileRejection[]) => {
     const first = rejections[0];
     const fileName = first?.file?.name ?? 'file';
+    const isTooLarge = first?.errors?.some((e) => e.code === 'file-too-large');
     const ext = fileName.includes('.') ? `.${fileName.split('.').pop()}` : 'unknown type';
     setErrorMessage(
-      `"${fileName}" was rejected — only .wasm files are accepted (got ${ext})`
+      isTooLarge
+        ? `"${fileName}" exceeds the ${MAX_WASM_SIZE / (1024 * 1024)} MB size limit`
+        : `"${fileName}" was rejected — only .wasm files are accepted (got ${ext})`
     );
     setUploadState('error');
     setDroppedFile(null);
@@ -225,6 +242,7 @@ export function UploadZone({ onFileReady }: UploadZoneProps) {
     onDragLeave,
     accept: { 'application/wasm': ['.wasm'] },
     maxFiles: 1,
+    maxSize: MAX_WASM_SIZE,
     noClick: uploadState === 'scanning',
     noDrag: uploadState === 'scanning',
   });


### PR DESCRIPTION
All changes are in place. Here's a summary of what was added to               
  upload-zone.tsx:                                                              
                                                                                
  Constants (lines 23–24)                                                       
                                                                                
  - MAX_WASM_SIZE = 5 MB — matches Soroban's practical contract size ceiling    
  - WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d] — the \0asm magic bytes every valid   
  WASM binary starts with                                                       
                                                                                
  `hasWasmMagic()` helper (line 26–28)                                          
                                                                                
  - Reads the first 4 bytes of the ArrayBuffer and checks them against the magic
  sequence — catches renamed non-WASM files that slip past the extension filter 
                                                                                
  `onDropAccepted` (line 198–199)                                               
                                                                                
  - After FileReader loads the buffer, validates magic bytes before proceeding  
  to the success state. If they don't match, transitions to error with a clear  
  message                                                                       
                                                                                
  `onDropRejected` (lines 217–221)                                              
                                                                                
  - Distinguishes between a size rejection (file-too-large error code) and a    
  type rejection, showing "exceeds the 5 MB size limit" vs the existing         
  extension mismatch message                                                    
                                                                                
  Dropzone config (line 245)                                                    
                                                                                
  - maxSize: MAX_WASM_SIZE passed to useDropzone so oversized files are rejected before any reading happens                                                    
 
closes #198 