### PR TITLE
fix(#203): Handle and render error responses from backend /analyze

### DIFF
--- a/web/components/Resultviewer.tsx
+++ b/web/components/Resultviewer.tsx
@@ -91,18 +91,35 @@ export function ResultViewer({ result }: ResultViewerProps) {
         <div
           style={{
             backgroundColor: '#0d1117',
-            padding: '12px',
+            padding: '16px',
             borderRadius: '6px',
             marginBottom: '12px',
             fontSize: '13px',
-            color: '#fb8500',
-            fontFamily: 'monospace',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-all',
-            border: '1px solid #30363d',
+            border: '1px solid #fb8500',
           }}
         >
-          {result.error}
+          <div style={{ marginBottom: '12px' }}>
+            <div style={{ color: '#fb8500', fontWeight: '600', marginBottom: '4px' }}>
+              Error Details
+            </div>
+            <div
+              style={{
+                backgroundColor: '#1a1f26',
+                padding: '12px',
+                borderRadius: '4px',
+                color: '#f0883e',
+                fontFamily: 'monospace',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                border: '1px solid #30363d',
+              }}
+            >
+              {result.error}
+            </div>
+          </div>
+          <div style={{ fontSize: '12px', color: '#8b949e' }}>
+            💡 Tip: Check if the backend is running and all parameters are correct.
+          </div>
         </div>
       ) : (
         result.result && (

--- a/web/components/Resultviewer.tsx
+++ b/web/components/Resultviewer.tsx
@@ -99,8 +99,24 @@ export function ResultViewer({ result }: ResultViewerProps) {
           }}
         >
           <div style={{ marginBottom: '12px' }}>
-            <div style={{ color: '#fb8500', fontWeight: '600', marginBottom: '4px' }}>
+            <div style={{ color: '#fb8500', fontWeight: '600', marginBottom: '8px', display: 'flex', alignItems: 'center', gap: '8px' }}>
               Error Details
+              {result.errorType && (
+                <span
+                  style={{
+                    fontSize: '11px',
+                    backgroundColor: '#2d1810',
+                    color: '#f0883e',
+                    padding: '2px 8px',
+                    borderRadius: '3px',
+                    border: '1px solid #fb8500',
+                    fontFamily: 'monospace',
+                    fontWeight: 'normal',
+                  }}
+                >
+                  {result.errorType}
+                </span>
+              )}
             </div>
             <div
               style={{

--- a/web/lib/errorHandling.ts
+++ b/web/lib/errorHandling.ts
@@ -1,0 +1,128 @@
+/**
+ * Error handling utilities for parsing and formatting backend error responses
+ */
+
+export interface BackendErrorResponse {
+  error: string;
+  message: string;
+  statusCode?: number;
+}
+
+export interface FormattedError {
+  type: string;
+  message: string;
+  details?: string;
+  statusCode: number;
+  isNetworkError: boolean;
+}
+
+/**
+ * Extract detailed error information from backend response
+ */
+export async function extractErrorDetails(response: Response): Promise<BackendErrorResponse> {
+  try {
+    const data = await response.json();
+    return {
+      error: data.error || 'UNKNOWN_ERROR',
+      message: data.message || response.statusText || 'An error occurred',
+      statusCode: response.status,
+    };
+  } catch {
+    // If response body is not JSON, use status text
+    return {
+      error: getErrorType(response.status),
+      message: response.statusText || 'An error occurred',
+      statusCode: response.status,
+    };
+  }
+}
+
+/**
+ * Map HTTP status codes to error types
+ */
+function getErrorType(status: number): string {
+  switch (status) {
+    case 400:
+      return 'BAD_REQUEST';
+    case 401:
+      return 'UNAUTHORIZED';
+    case 404:
+      return 'NOT_FOUND';
+    case 500:
+      return 'INTERNAL_SERVER_ERROR';
+    case 503:
+      return 'SERVICE_UNAVAILABLE';
+    default:
+      return 'UNKNOWN_ERROR';
+  }
+}
+
+/**
+ * Format error for display
+ */
+export function formatError(error: unknown): FormattedError {
+  if (error instanceof Response) {
+    return {
+      type: getErrorType(error.status),
+      message: error.statusText || 'Network error',
+      statusCode: error.status,
+      isNetworkError: true,
+    };
+  }
+
+  if (error instanceof TypeError) {
+    return {
+      type: 'NETWORK_ERROR',
+      message: 'Failed to connect to backend. Please ensure the server is running.',
+      details: error.message,
+      statusCode: 0,
+      isNetworkError: true,
+    };
+  }
+
+  if (error instanceof Error) {
+    // Check if it's a JSON parse error
+    if (error.message.includes('JSON')) {
+      return {
+        type: 'PARSE_ERROR',
+        message: 'Failed to parse response from backend',
+        details: error.message,
+        statusCode: 0,
+        isNetworkError: false,
+      };
+    }
+
+    return {
+      type: 'ERROR',
+      message: error.message || 'An unexpected error occurred',
+      statusCode: 0,
+      isNetworkError: false,
+    };
+  }
+
+  return {
+    type: 'UNKNOWN_ERROR',
+    message: 'An unexpected error occurred',
+    statusCode: 0,
+    isNetworkError: false,
+  };
+}
+
+/**
+ * Create a user-friendly error message from BackendErrorResponse
+ */
+export function createUserFriendlyMessage(errorResponse: BackendErrorResponse): string {
+  const errorMessages: Record<string, string> = {
+    BAD_REQUEST: 'Invalid request. Please check your inputs and try again.',
+    UNAUTHORIZED: 'You are not authorized to perform this action.',
+    NOT_FOUND: 'The requested resource was not found.',
+    INTERNAL_SERVER_ERROR: 'Server error. Please try again later.',
+    SERVICE_UNAVAILABLE: 'The service is currently unavailable. Please try again later.',
+  };
+
+  return (
+    errorMessages[errorResponse.error] ||
+    errorResponse.message ||
+    'An error occurred during analysis'
+  );
+}

--- a/web/lib/sorobantypes.ts
+++ b/web/lib/sorobantypes.ts
@@ -19,6 +19,7 @@ export interface InvocationResult {
   inputs: Record<string, any>;
   result?: any;
   error?: string;
+  errorType?: string; // Error type from backend (e.g., BAD_REQUEST, INTERNAL_SERVER_ERROR)
   resourceCost?: {
     fee?: string;
     cpu_instructions: number;

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -9,6 +9,7 @@ import { ContractInteraction } from '../components/ContractInteraction';
 import { MOCK_CONTRACT_FUNCTIONS, generateMockResult, generateMockResourceCost } from '../lib/sorobantypes';
 import type { ContractFunction, InvocationResult } from '../lib/sorobantypes';
 import { UploadZone } from '../components/upload-zone';
+import { extractErrorDetails, createUserFriendlyMessage } from '../lib/errorHandling';
 
 export default function Home() {
   const [contractId, setContractId] = useState('CAEZJVJ4N7P7GRUVD5NG5LYYH23AQHJUKQEUHW54LR5PGQX3V7FXD7Q');
@@ -31,7 +32,10 @@ export default function Home() {
       });
 
       if (!response.ok) {
-        throw new Error(`Backend error: ${response.statusText}`);
+        // Parse error response from backend
+        const errorResponse = await extractErrorDetails(response);
+        const userMessage = createUserFriendlyMessage(errorResponse);
+        throw new Error(userMessage);
       }
 
       const report = await response.json();
@@ -49,11 +53,13 @@ export default function Home() {
       setCurrentResult(result);
       addToHistory(result);
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred during analysis';
+      
       const errorResult: InvocationResult = {
         id: Math.random().toString(36).substring(7),
         functionName: selectedFunction.name,
         inputs,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        error: errorMessage,
         timestamp: Date.now(),
         success: false,
       };

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -21,6 +21,7 @@ export default function Home() {
 
   const handleSimulate = async (inputs: Record<string, any>) => {
     setLoading(true);
+    let errorType: string | undefined;
     try {
       const response = await fetch('http://localhost:8080/analyze', {
         method: 'POST',
@@ -34,6 +35,7 @@ export default function Home() {
       if (!response.ok) {
         // Parse error response from backend
         const errorResponse = await extractErrorDetails(response);
+        errorType = errorResponse.error;
         const userMessage = createUserFriendlyMessage(errorResponse);
         throw new Error(userMessage);
       }
@@ -60,6 +62,7 @@ export default function Home() {
         functionName: selectedFunction.name,
         inputs,
         error: errorMessage,
+        errorType: errorType || 'UNKNOWN_ERROR',
         timestamp: Date.now(),
         success: false,
       };


### PR DESCRIPTION
Fixes #203

This PR properly parses and renders error states when the Rust backend fails to simulate or analyze the uploaded WASM.

## Changes Made

1. Error Handling Utility - Created web/lib/errorHandling.ts for parsing backend error responses  
2. Updated Fetch Handler - Modified handleSimulate to use error utilities
3. Enhanced Error Display - Improved error rendering with better formatting
4. Type Enhancements - Extended InvocationResult with errorType field

## Testing
Error handling properly parses JSON responses, displays error types and messages, shows helpful tips, and handles network errors.