### PR TITLE
feat(#224): Replace generic pause with guard_unpause in token

### DIFF
--- a/contracts/token/src/contract.rs
+++ b/contracts/token/src/contract.rs
@@ -2,7 +2,8 @@ use crate::admin::{has_administrator, read_administrator, write_administrator};
 use crate::allowance::{read_allowance, spend_allowance, write_allowance};
 use crate::balance::{read_balance, receive_balance, spend_balance};
 use crate::metadata::{read_decimal, read_name, read_symbol, write_metadata};
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use emergency_guard::{EmergencyGuard, GuardError};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 pub trait TokenTrait {
     fn initialize(e: Env, admin: Address, decimal: u32, name: String, symbol: String);
@@ -18,6 +19,8 @@ pub trait TokenTrait {
     fn decimals(e: Env) -> u32;
     fn name(e: Env) -> String;
     fn symbol(e: Env) -> String;
+    fn guard_pause(e: Env, admin: Address, operation: u32, paused: bool) -> Result<(), GuardError>;
+    fn guard_unpause(e: Env, approvers: Vec<Address>) -> Result<(), GuardError>;
 }
 
 #[contract]

--- a/contracts/token/src/contract.rs
+++ b/contracts/token/src/contract.rs
@@ -48,6 +48,11 @@ impl TokenTrait for Token {
         admin.require_auth();
         e.storage().instance().extend_ttl(100, 100);
 
+        // Check if minting is paused (using MINT pause type = 1 << 4 = 16)
+        if EmergencyGuard::is_paused(e.clone(), 1 << 4) {
+            panic!("minting is paused");
+        }
+
         receive_balance(&e, to, amount);
     }
 
@@ -80,6 +85,11 @@ impl TokenTrait for Token {
         from.require_auth();
         e.storage().instance().extend_ttl(100, 100);
 
+        // Check if transfers are paused (using TRANSFER pause type = 1 << 3 = 8)
+        if EmergencyGuard::is_paused(e.clone(), 1 << 3) {
+            panic!("transfers are paused");
+        }
+
         spend_balance(&e, from, amount);
         receive_balance(&e, to, amount);
     }
@@ -87,6 +97,11 @@ impl TokenTrait for Token {
     fn transfer_from(e: Env, spender: Address, from: Address, to: Address, amount: i128) {
         spender.require_auth();
         e.storage().instance().extend_ttl(100, 100);
+
+        // Check if transfers are paused (using TRANSFER pause type = 1 << 3 = 8)
+        if EmergencyGuard::is_paused(e.clone(), 1 << 3) {
+            panic!("transfers are paused");
+        }
 
         spend_allowance(&e, from.clone(), spender, amount);
         spend_balance(&e, from, amount);
@@ -97,12 +112,22 @@ impl TokenTrait for Token {
         from.require_auth();
         e.storage().instance().extend_ttl(100, 100);
 
+        // Check if burning is paused (using BURN pause type = 1 << 5 = 32)
+        if EmergencyGuard::is_paused(e.clone(), 1 << 5) {
+            panic!("burning is paused");
+        }
+
         spend_balance(&e, from, amount);
     }
 
     fn burn_from(e: Env, spender: Address, from: Address, amount: i128) {
         spender.require_auth();
         e.storage().instance().extend_ttl(100, 100);
+
+        // Check if burning is paused (using BURN pause type = 1 << 5 = 32)
+        if EmergencyGuard::is_paused(e.clone(), 1 << 5) {
+            panic!("burning is paused");
+        }
 
         spend_allowance(&e, from.clone(), spender, amount);
         spend_balance(&e, from, amount);

--- a/contracts/token/src/contract.rs
+++ b/contracts/token/src/contract.rs
@@ -113,4 +113,12 @@ impl TokenTrait for Token {
     fn symbol(e: Env) -> String {
         read_symbol(&e)
     }
+
+    fn guard_pause(e: Env, admin: Address, operation: u32, paused: bool) -> Result<(), GuardError> {
+        EmergencyGuard::set_pause(e, admin, operation, paused)
+    }
+
+    fn guard_unpause(e: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
+        EmergencyGuard::resume(e, approvers)
+    }
 }

--- a/contracts/token/src/contract.rs
+++ b/contracts/token/src/contract.rs
@@ -35,6 +35,12 @@ impl TokenTrait for Token {
         write_administrator(&e, &admin);
         // One write instead of three separate writes for name/symbol/decimals.
         write_metadata(&e, &name, &symbol, decimal);
+        
+        // Initialize emergency guard with single admin and threshold of 1
+        let admins = vec![&e, admin.clone()];
+        let threshold = 1;
+        EmergencyGuard::initialize(e, admins, threshold)
+            .expect("Failed to initialize emergency guard");
     }
 
     fn mint(e: Env, to: Address, amount: i128) {


### PR DESCRIPTION
Fixes #224

This PR implements the unpause logic utilizing the EmergencyGuard trait for the token contract, providing standardized multi-signature and granular pause controls.

## Changes Made

1. Added guard_pause and guard_unpause method signatures to TokenTrait
2. Implemented guard_pause and guard_unpause methods using EmergencyGuard
3. Initialize EmergencyGuard on token initialization with the token admin
4. Added pause checks to mint, transfer (including transfer_from), and burn (including burn_from) operations
5. Used granular pause types for specific operations:
   - MINT (1 << 4): Controls minting
   - TRANSFER (1 << 3): Controls transfers
   - BURN (1 << 5): Controls burning

## Features

- Granular pausing: Admins can pause specific operations independently
- Multi-signature support: Resume operations require multi-sig approval
- Emergency controls: Full pause/unpause capabilities using EmergencyGuard trait
- Secure: Enforces authorization checks and multi-sig when needed

## Integration with EmergencyGuard

The token contract now integrates with the EmergencyGuard trait which provides:
- Single admin can pause specific operations
- Multi-sig approval required to resume all operations
- Bitmask-based pause state for efficient storage
- Comprehensive admin management capabilities

## Commits
1. feat(#224): Add guard_pause and guard_unpause methods to TokenTrait
2. feat(#224): Implement guard_pause functionality using EmergencyGuard
3. feat(#224): Initialize EmergencyGuard on token initialization
4. feat(#224): Add pause checks to mint, transfer, and burn operations