### PR TITLE
Updated liquidity_pool Cargo.toml to include emergency_guard dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ members = [
     "contracts/typed_data_auth",
     "contracts/proxy",
     "contracts/flash_loan_vault",
+    "contracts/emergency_guard",
 ]


### PR DESCRIPTION
## Description

This PR fixes a workspace dependency resolution issue by properly registering the newly created `emergency_guard` crate. While the crate was correctly specified as a dependency in the `liquidity_pool` contract, it was missing from the root workspace configuration, which prevented proper workspace-level builds and lockfile resolution.

Closes #207 

### Changes Made
- Added `"contracts/emergency_guard"` to the `members` array in the root `Cargo.toml`.

### Why is this needed?
Adding new contracts to the Cargo workspace `members` array ensures they are included in workspace-wide commands (like `cargo check`, `cargo build`, and `cargo test`). It also ensures they share the unified `Cargo.lock` file, which is required for the `liquidity_pool` contract to correctly resolve the local `path = "../emergency_guard"` dependency.

### How to Test
1. Run `cargo check` at the workspace root to confirm all crates, including `emergency_guard` and `liquidity_pool`, resolve without errors.
2. Run `cargo build -p liquidity_pool` to verify the contract compiles successfully with the new dependency.
