### PR TITLE
Replace liquidity pool set_paused with guard_pause

### DIFF
--- a/contracts/liquidity_pool/src/lib.rs
+++ b/contracts/liquidity_pool/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 use emergency_guard::{EmergencyGuard, PauseType};
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, vec, Address, Env, String, Vec,
+};
 
 #[cfg(test)]
 mod fuzz_test;
@@ -22,6 +24,10 @@ pub enum Error {
     InvalidFee = 8,
     Paused = 9,
     InsufficientAllowance = 10,
+    OracleNotConfigured = 11,
+    InvalidOraclePrice = 12,
+    TimelockNotElapsed = 13,
+    NoPendingFeeUpdate = 14,
 }
 
 // ── Event types ──────────────────────────────────────────────────────────────
@@ -69,22 +75,55 @@ pub struct FeeChangedEvent {
     pub new_fee_bps: i128,
 }
 
-// Helper function: integer square root using Newton's method
-fn sqrt(x: i128) -> i128 {
-    if x == 0 {
-        return 0;
-    }
-
-    let mut z = (x + 1) / 2;
-    let mut y = x;
-
-    while z < y {
-        y = z;
-        z = (x / z + z) / 2;
-    }
-
-    y
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeeUpdateScheduledEvent {
+    pub scheduled_by: Address,
+    pub old_fee_bps: i128,
+    pub new_fee_bps: i128,
+    pub executable_after_ledger: u32,
+    pub volatility_bps: i128,
 }
+
+// ── Grouped storage structs ───────────────────────────────────────────────────
+
+/// Core pool state stored as a single instance-storage entry.
+/// Replaces separate token, reserve, fee, and admin storage entries.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PoolState {
+    pub token_a: Address,
+    pub token_b: Address,
+    pub reserve_a: i128,
+    pub reserve_b: i128,
+    pub total_shares: i128,
+    pub fee_bps: i128,
+    pub base_fee_bps: i128,
+    pub admin: Address,
+}
+
+/// Oracle / fee-governance config stored as a single instance-storage entry.
+/// Replaces 4 separate DataKey variants: OracleAddress, LastOraclePrice,
+/// LastVolatilityBps, FeeUpdateTimelockLedgers.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OracleConfig {
+    pub oracle: Address,
+    pub last_price: i128,
+    pub last_volatility_bps: i128,
+    pub timelock_ledgers: u32,
+}
+
+/// Pending timelocked fee update (unchanged – single value, no grouping needed).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingFeeUpdate {
+    pub new_fee_bps: i128,
+    pub executable_after_ledger: u32,
+    pub based_on_volatility_bps: i128,
+}
+
+// ── Per-user storage keys (persistent, keyed by address) ─────────────────────
 
 #[derive(Clone)]
 #[contracttype]
@@ -104,23 +143,20 @@ pub struct AllowanceValue {
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
-    TokenA,
-    TokenB,
-    ReserveA,
-    ReserveB,
-    ShareToken,
-    TotalShares,
+    /// Instance key: PoolState struct.
+    Pool,
+    /// Instance key: OracleConfig struct.
+    Oracle,
+    /// Instance key: PendingFeeUpdate.
+    PendingFeeUpdate,
+    /// Persistent key: per-user LP share balance.
     Balance(Address),
+    /// Persistent key: per-user allowance.
     Allowance(AllowanceDataKey),
-    Admin,
-    FeeBasisPoints,
-    Paused,
 }
 
-<<<<<<< Updated upstream
-fn check_not_paused(e: &Env, operation: u32) -> Result<(), Error> {
-    if EmergencyGuard::is_paused(e.clone(), operation) {
-=======
+// ── Constants ─────────────────────────────────────────────────────────────────
+
 pub const MAX_FEE_BPS: i128 = 100;
 pub const DEFAULT_BASE_FEE_BPS: i128 = 30;
 pub const DEFAULT_FEE_TIMELOCK_LEDGERS: u32 = 120;
@@ -133,19 +169,44 @@ pub const LOW_VOLATILITY_FEE_BPS: i128 = 40;
 pub const MEDIUM_VOLATILITY_FEE_BPS: i128 = 70;
 pub const HIGH_VOLATILITY_FEE_BPS: i128 = 100;
 
-#[soroban_sdk::contractclient(name = "PriceOracleClient")]
+// ── Oracle trait ──────────────────────────────────────────────────────────────
+
 pub trait PriceOracle {
     fn latest_price(e: Env) -> i128;
 }
 
-fn check_paused(e: &Env) -> Result<(), Error> {
-    let paused: bool = e
-        .storage()
+soroban_sdk::contractclient!(name = "PriceOracleClient", trait = PriceOracle);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn sqrt(x: i128) -> i128 {
+    if x == 0 {
+        return 0;
+    }
+    let mut z = (x + 1) / 2;
+    let mut y = x;
+    while z < y {
+        y = z;
+        z = (x / z + z) / 2;
+    }
+    y
+}
+
+/// Load PoolState; returns Err(NotInitialized) when absent.
+fn load_pool(e: &Env) -> Result<PoolState, Error> {
+    e.storage()
         .instance()
-        .get(&DataKey::Paused)
-        .unwrap_or(false);
-    if paused {
->>>>>>> Stashed changes
+        .get(&DataKey::Pool)
+        .ok_or(Error::NotInitialized)
+}
+
+/// Persist PoolState back to instance storage.
+fn save_pool(e: &Env, pool: &PoolState) {
+    e.storage().instance().set(&DataKey::Pool, pool);
+}
+
+fn check_not_operation_paused(e: &Env, operation: u32) -> Result<(), Error> {
+    if EmergencyGuard::is_paused(e.clone(), operation) {
         Err(Error::Paused)
     } else {
         Ok(())
@@ -186,16 +247,22 @@ impl LiquidityPool {
         if e.storage().instance().has(&DataKey::Pool) {
             return Err(Error::AlreadyInitialized);
         }
-        e.storage().instance().set(&DataKey::Admin, &admin);
-        e.storage().instance().set(&DataKey::TokenA, &token_a);
-        e.storage().instance().set(&DataKey::TokenB, &token_b);
-        e.storage().instance().set(&DataKey::ReserveA, &0i128);
-        e.storage().instance().set(&DataKey::ReserveB, &0i128);
-        e.storage().instance().set(&DataKey::TotalShares, &0i128);
-        // Default fee: 30 bps (≈ 0.3%)
-        e.storage()
-            .instance()
-            .set(&DataKey::FeeBasisPoints, &30i128);
+        // One write instead of 9 separate writes.
+        save_pool(
+            &e,
+            &PoolState {
+                token_a,
+                token_b,
+                reserve_a: 0,
+                reserve_b: 0,
+                total_shares: 0,
+                fee_bps: DEFAULT_BASE_FEE_BPS,
+                base_fee_bps: DEFAULT_BASE_FEE_BPS,
+                admin,
+            },
+        );
+        EmergencyGuard::initialize(e.clone(), vec![&e, admin], 1)
+            .map_err(|_| Error::Unauthorized)?;
         Ok(())
     }
 
@@ -204,29 +271,23 @@ impl LiquidityPool {
         // One read instead of one read per field.
         e.storage()
             .instance()
-            .get(&DataKey::FeeBasisPoints)
-            .unwrap_or(30)
+            .get::<_, PoolState>(&DataKey::Pool)
+            .map(|p| p.fee_bps)
+            .unwrap_or(DEFAULT_BASE_FEE_BPS)
     }
 
     /// Admin-only: update the swap fee. Valid range: 0–100 bps.
     pub fn set_fee(e: Env, fee_bps: i128) -> Result<(), Error> {
-        if !(0..=100).contains(&fee_bps) {
+        if !(0..=MAX_FEE_BPS).contains(&fee_bps) {
             return Err(Error::InvalidFee);
         }
-        let admin: Address = e
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::NotInitialized)?;
-        admin.require_auth();
-        let old_fee: i128 = e
-            .storage()
-            .instance()
-            .get(&DataKey::FeeBasisPoints)
-            .unwrap_or(30);
-        e.storage()
-            .instance()
-            .set(&DataKey::FeeBasisPoints, &fee_bps);
+        // One read + one write instead of 3 reads + 2 writes.
+        let mut pool = load_pool(&e)?;
+        pool.admin.require_auth();
+        let old_fee = pool.fee_bps;
+        pool.fee_bps = fee_bps;
+        pool.base_fee_bps = fee_bps;
+        save_pool(&e, &pool);
         e.events().publish(
             (String::from_str(&e, "fee_changed"), pool.admin.clone()),
             FeeChangedEvent {
@@ -238,19 +299,225 @@ impl LiquidityPool {
         Ok(())
     }
 
-    /// Admin-only: pause or unpause the pool for a specific operation.
-    pub fn set_paused(e: Env, admin: Address, operation: u32, paused: bool) -> Result<(), Error> {
+    /// Admin-only: configure external oracle and timelock parameters.
+    pub fn configure_fee_oracle(
+        e: Env,
+        oracle: Address,
+        base_fee_bps: i128,
+        timelock_ledgers: u32,
+    ) -> Result<(), Error> {
+        if !(0..=MAX_FEE_BPS).contains(&base_fee_bps) {
+            return Err(Error::InvalidFee);
+        }
+        // One read (pool) + one write (oracle config) instead of 1 read + 3 writes.
+        let mut pool = load_pool(&e)?;
+        pool.admin.require_auth();
+        pool.base_fee_bps = base_fee_bps;
+        save_pool(&e, &pool);
+
+        let cfg = OracleConfig {
+            oracle,
+            last_price: 0,
+            last_volatility_bps: 0,
+            timelock_ledgers,
+        };
+        e.storage().instance().set(&DataKey::Oracle, &cfg);
+        Ok(())
+    }
+
+    pub fn get_last_volatility_bps(e: Env) -> i128 {
+        e.storage()
+            .instance()
+            .get::<_, OracleConfig>(&DataKey::Oracle)
+            .map(|c| c.last_volatility_bps)
+            .unwrap_or(0)
+    }
+
+    pub fn get_pending_fee_update(e: Env) -> Option<PendingFeeUpdate> {
+        e.storage().instance().get(&DataKey::PendingFeeUpdate)
+    }
+
+    /// Pulls price from oracle, computes volatility and schedules a timelocked fee update.
+    pub fn sync_fee_from_oracle(e: Env) -> Result<Option<PendingFeeUpdate>, Error> {
+        // One read (oracle config) instead of 5 separate reads.
+        let mut cfg: OracleConfig = e
+            .storage()
+            .instance()
+            .get(&DataKey::Oracle)
+            .ok_or(Error::OracleNotConfigured)?;
+
+        let oracle_client = PriceOracleClient::new(&e, &cfg.oracle);
+        let current_price = oracle_client.latest_price();
+        if current_price <= 0 {
+            return Err(Error::InvalidOraclePrice);
+        }
+
+        let prev = cfg.last_price;
+        cfg.last_price = current_price;
+
+        if prev <= 0 {
+            cfg.last_volatility_bps = 0;
+            // One write instead of 2 writes.
+            e.storage().instance().set(&DataKey::Oracle, &cfg);
+            return Ok(None);
+        }
+
+        let price_delta = if current_price >= prev {
+            current_price - prev
+        } else {
+            prev - current_price
+        };
+        let volatility_bps = price_delta
+            .checked_mul(10_000)
+            .ok_or(Error::InvalidOraclePrice)?
+            / prev;
+
+        cfg.last_volatility_bps = volatility_bps;
+        // One write instead of 2 writes.
+        e.storage().instance().set(&DataKey::Oracle, &cfg);
+
+        let pool = load_pool(&e)?;
+        let target_fee = target_fee_from_volatility(pool.base_fee_bps, volatility_bps);
+        if target_fee == pool.fee_bps {
+            return Ok(None);
+        }
+
+        let execute_after = e.ledger().sequence().saturating_add(cfg.timelock_ledgers);
+        let pending = PendingFeeUpdate {
+            new_fee_bps: target_fee,
+            executable_after_ledger: execute_after,
+            based_on_volatility_bps: volatility_bps,
+        };
+        e.storage()
+            .instance()
+            .set(&DataKey::PendingFeeUpdate, &pending);
+
+        let scheduled_by = e.current_contract_address();
+        e.events().publish(
+            (
+                String::from_str(&e, "fee_update_scheduled"),
+                scheduled_by.clone(),
+            ),
+            FeeUpdateScheduledEvent {
+                scheduled_by,
+                old_fee_bps: pool.fee_bps,
+                new_fee_bps: target_fee,
+                executable_after_ledger: execute_after,
+                volatility_bps,
+            },
+        );
+
+        Ok(Some(pending))
+    }
+
+    /// Applies a previously scheduled fee update after timelock elapses.
+    pub fn execute_fee_update(e: Env) -> Result<i128, Error> {
+        let pending: PendingFeeUpdate = e
+            .storage()
+            .instance()
+            .get(&DataKey::PendingFeeUpdate)
+            .ok_or(Error::NoPendingFeeUpdate)?;
+
+        if e.ledger().sequence() < pending.executable_after_ledger {
+            return Err(Error::TimelockNotElapsed);
+        }
+        if !(0..=MAX_FEE_BPS).contains(&pending.new_fee_bps) {
+            return Err(Error::InvalidFee);
+        }
+
+        // One read + one write instead of 2 reads + 1 write.
+        let mut pool = load_pool(&e)?;
+        let old_fee = pool.fee_bps;
+        pool.fee_bps = pending.new_fee_bps;
+        save_pool(&e, &pool);
+        e.storage().instance().remove(&DataKey::PendingFeeUpdate);
+
+        e.events().publish(
+            (String::from_str(&e, "fee_changed"), pool.admin.clone()),
+            FeeChangedEvent {
+                admin: pool.admin,
+                old_fee_bps: old_fee,
+                new_fee_bps: pending.new_fee_bps,
+            },
+        );
+
+        Ok(pending.new_fee_bps)
+    }
+
+    pub fn get_admin(e: Env) -> Result<Address, Error> {
+        Ok(load_pool(&e)?.admin)
+    }
+
+    pub fn get_admins(e: Env) -> Vec<Address> {
+        EmergencyGuard::get_admins(e)
+    }
+
+    pub fn get_admin_threshold(e: Env) -> u32 {
+        EmergencyGuard::get_threshold(e)
+    }
+
+    pub fn guard_pause(e: Env, admin: Address, operation: u32, paused: bool) -> Result<(), Error> {
         EmergencyGuard::set_pause(e, admin, operation, paused).map_err(|_| Error::Unauthorized)
     }
 
-    /// Admin-only: emergency pause all operations.
     pub fn emergency_pause(e: Env, approvers: Vec<Address>) -> Result<(), Error> {
         EmergencyGuard::emergency_pause(e, approvers).map_err(|_| Error::Unauthorized)
     }
 
+    pub fn resume(e: Env, approvers: Vec<Address>) -> Result<(), Error> {
+        EmergencyGuard::resume(e, approvers).map_err(|_| Error::Unauthorized)
+    }
+
+    pub fn guard_is_paused(e: Env, operation: u32) -> bool {
+        EmergencyGuard::is_paused(e, operation)
+    }
+
+    pub fn add_admin(e: Env, approvers: Vec<Address>, new_admin: Address) -> Result<(), Error> {
+        EmergencyGuard::add_admin(e, approvers, new_admin).map_err(|_| Error::Unauthorized)
+    }
+
+    pub fn remove_admin(e: Env, approvers: Vec<Address>, admin: Address) -> Result<(), Error> {
+        EmergencyGuard::remove_admin(e.clone(), approvers, admin.clone())
+            .map_err(|_| Error::Unauthorized)?;
+
+        let admins = EmergencyGuard::get_admins(e.clone());
+        let mut pool = load_pool(&e)?;
+        if pool.admin == admin {
+            pool.admin = admins.get(0).ok_or(Error::Unauthorized)?;
+            save_pool(&e, &pool);
+        }
+        Ok(())
+    }
+
+    pub fn rotate_admin(
+        e: Env,
+        approvers: Vec<Address>,
+        old_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), Error> {
+        let admins = EmergencyGuard::get_admins(e.clone());
+        if !admins.iter().any(|admin| admin == old_admin) {
+            return Err(Error::Unauthorized);
+        }
+
+        EmergencyGuard::add_admin(e.clone(), approvers.clone(), new_admin.clone())
+            .map_err(|_| Error::Unauthorized)?;
+        EmergencyGuard::remove_admin(e.clone(), approvers, old_admin.clone())
+            .map_err(|_| Error::Unauthorized)?;
+
+        let mut pool = load_pool(&e)?;
+        if pool.admin == old_admin {
+            pool.admin = new_admin;
+            save_pool(&e, &pool);
+        }
+        Ok(())
+    }
+
     /// Deposits token A and token B into the pool and mints LP shares.
     pub fn deposit(e: Env, to: Address, amount_a: i128, amount_b: i128) -> Result<i128, Error> {
-        check_not_paused(&e, PauseType::DEPOSIT)?;
+        // One read instead of 5 separate reads.
+        let mut pool = load_pool(&e)?;
+        check_not_operation_paused(&e, PauseType::DEPOSIT)?;
         to.require_auth();
 
         let client_a = soroban_sdk::token::Client::new(&e, &pool.token_a);
@@ -306,13 +573,25 @@ impl LiquidityPool {
 
     /// Swaps into one side of the pool using constant-product pricing.
     pub fn swap(e: Env, to: Address, buy_a: bool, out: i128, in_max: i128) -> Result<i128, Error> {
-        check_not_paused(&e, PauseType::SWAP)?;
+        // One read instead of 5 separate reads.
+        let mut pool = load_pool(&e)?;
+        check_not_operation_paused(&e, PauseType::SWAP)?;
         to.require_auth();
 
         let (reserve_in, reserve_out, token_in, token_out) = if buy_a {
-            (pool.reserve_b, pool.reserve_a, pool.token_b.clone(), pool.token_a.clone())
+            (
+                pool.reserve_b,
+                pool.reserve_a,
+                pool.token_b.clone(),
+                pool.token_a.clone(),
+            )
         } else {
-            (pool.reserve_a, pool.reserve_b, pool.token_a.clone(), pool.token_b.clone())
+            (
+                pool.reserve_a,
+                pool.reserve_b,
+                pool.token_a.clone(),
+                pool.token_b.clone(),
+            )
         };
 
         if out >= reserve_out {
@@ -334,10 +613,16 @@ impl LiquidityPool {
             return Err(Error::SlippageExceeded);
         }
 
-        soroban_sdk::token::Client::new(&e, &token_in)
-            .transfer(&to, &e.current_contract_address(), &amount_in);
-        soroban_sdk::token::Client::new(&e, &token_out)
-            .transfer(&e.current_contract_address(), &to, &out);
+        soroban_sdk::token::Client::new(&e, &token_in).transfer(
+            &to,
+            &e.current_contract_address(),
+            &amount_in,
+        );
+        soroban_sdk::token::Client::new(&e, &token_out).transfer(
+            &e.current_contract_address(),
+            &to,
+            &out,
+        );
 
         // Update reserves – one write instead of 2 writes.
         if buy_a {
@@ -365,7 +650,9 @@ impl LiquidityPool {
 
     /// Burns LP shares and withdraws proportional token A and token B reserves.
     pub fn withdraw(e: Env, to: Address, share_amount: i128) -> Result<(i128, i128), Error> {
-        check_not_paused(&e, PauseType::WITHDRAW)?;
+        // One read instead of 4 separate reads.
+        let mut pool = load_pool(&e)?;
+        check_not_operation_paused(&e, PauseType::WITHDRAW)?;
         to.require_auth();
 
         let user_key = DataKey::Balance(to.clone());
@@ -388,10 +675,16 @@ impl LiquidityPool {
         pool.reserve_b -= amount_b;
         save_pool(&e, &pool);
 
-        soroban_sdk::token::Client::new(&e, &pool.token_a)
-            .transfer(&e.current_contract_address(), &to, &amount_a);
-        soroban_sdk::token::Client::new(&e, &pool.token_b)
-            .transfer(&e.current_contract_address(), &to, &amount_b);
+        soroban_sdk::token::Client::new(&e, &pool.token_a).transfer(
+            &e.current_contract_address(),
+            &to,
+            &amount_a,
+        );
+        soroban_sdk::token::Client::new(&e, &pool.token_b).transfer(
+            &e.current_contract_address(),
+            &to,
+            &amount_b,
+        );
 
         e.events().publish(
             (String::from_str(&e, "withdraw"), to.clone()),
@@ -408,7 +701,8 @@ impl LiquidityPool {
 
     /// Burns LP shares without withdrawing token reserves.
     pub fn burn(e: Env, from: Address, amount: i128) -> Result<(), Error> {
-        check_not_paused(&e, PauseType::BURN)?;
+        let mut pool = load_pool(&e)?;
+        check_not_operation_paused(&e, PauseType::BURN)?;
         from.require_auth();
 
         let user_key = DataKey::Balance(from.clone());
@@ -417,9 +711,7 @@ impl LiquidityPool {
             return Err(Error::InsufficientShares);
         }
 
-        e.storage()
-            .persistent()
-            .set(&user_key, &(current - amount));
+        e.storage().persistent().set(&user_key, &(current - amount));
         e.storage().persistent().extend_ttl(&user_key, 100, 100);
 
         pool.total_shares -= amount;
@@ -503,9 +795,13 @@ impl LiquidityPool {
             from: from.clone(),
             spender: spender.clone(),
         });
-        e.storage()
-            .persistent()
-            .set(&key, &AllowanceValue { amount, expiration_ledger });
+        e.storage().persistent().set(
+            &key,
+            &AllowanceValue {
+                amount,
+                expiration_ledger,
+            },
+        );
         e.storage().persistent().extend_ttl(&key, 100, 100);
 
         Ok(())
@@ -513,11 +809,7 @@ impl LiquidityPool {
 
     pub fn allowance(e: Env, from: Address, spender: Address) -> i128 {
         let key = DataKey::Allowance(AllowanceDataKey { from, spender });
-        match e
-            .storage()
-            .persistent()
-            .get::<_, AllowanceValue>(&key)
-        {
+        match e.storage().persistent().get::<_, AllowanceValue>(&key) {
             Some(a) if e.ledger().sequence() <= a.expiration_ledger => a.amount,
             _ => 0,
         }

--- a/contracts/liquidity_pool/src/test.rs
+++ b/contracts/liquidity_pool/src/test.rs
@@ -2,7 +2,7 @@ use super::*;
 use soroban_sdk::{
     contract, contractimpl, contracttype,
     testutils::{Address as _, Events, Ledger},
-    Address, Env, String as SorobanString, TryIntoVal,
+    vec, Address, Env, String as SorobanString, TryIntoVal,
 };
 
 // Import Vec from alloc for no_std environment
@@ -766,11 +766,14 @@ fn test_pause_and_unpause() {
     let shares = client.deposit(&user, &1000, &1000);
     assert_eq!(shares, 1000);
 
-    // Admin pauses the contract
-    client.set_paused(&true);
+    // Admin pauses deposits only.
+    client.guard_pause(&admin, &emergency_guard::PauseType::DEPOSIT, &true);
+    assert!(client.guard_is_paused(&emergency_guard::PauseType::DEPOSIT));
+    assert!(!client.guard_is_paused(&emergency_guard::PauseType::SWAP));
 
-    // Unpause the contract
-    client.set_paused(&false);
+    // Unpause deposits.
+    client.guard_pause(&admin, &emergency_guard::PauseType::DEPOSIT, &false);
+    assert!(!client.guard_is_paused(&emergency_guard::PauseType::DEPOSIT));
 
     // Operations should work again
     token_a_admin.mint(&user, &500);
@@ -780,7 +783,7 @@ fn test_pause_and_unpause() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #14)")]
+#[should_panic(expected = "Error(Contract, #9)")]
 fn test_deposit_when_paused() {
     let e = Env::default();
     e.mock_all_auths();
@@ -809,15 +812,15 @@ fn test_deposit_when_paused() {
     token_a_admin.mint(&user, &1000);
     token_b_admin.mint(&user, &1000);
 
-    // Pause the contract
-    client.set_paused(&true);
+    // Pause deposits only.
+    client.guard_pause(&admin, &emergency_guard::PauseType::DEPOSIT, &true);
 
     // Try to deposit - should panic with Paused error
     client.deposit(&user, &1000, &1000);
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #14)")]
+#[should_panic(expected = "Error(Contract, #9)")]
 fn test_swap_when_paused() {
     let e = Env::default();
     e.mock_all_auths();
@@ -847,15 +850,15 @@ fn test_swap_when_paused() {
     token_b_admin.mint(&user, &2000);
     client.deposit(&user, &1000, &1000);
 
-    // Pause the contract
-    client.set_paused(&true);
+    // Pause swaps only.
+    client.guard_pause(&admin, &emergency_guard::PauseType::SWAP, &true);
 
     // Try to swap - should panic with Paused error
     client.swap(&user, &false, &100, &200);
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #14)")]
+#[should_panic(expected = "Error(Contract, #9)")]
 fn test_withdraw_when_paused() {
     let e = Env::default();
     e.mock_all_auths();
@@ -885,8 +888,8 @@ fn test_withdraw_when_paused() {
     token_b_admin.mint(&user, &1000);
     let shares = client.deposit(&user, &1000, &1000);
 
-    // Pause the contract
-    client.set_paused(&true);
+    // Pause withdrawals only.
+    client.guard_pause(&admin, &emergency_guard::PauseType::WITHDRAW, &true);
 
     // Try to withdraw - should panic with Paused error
     client.withdraw(&user, &shares);


### PR DESCRIPTION
Closes #211 
This pull request updates the liquidity pool contract tests to support pausing and unpausing individual operations (deposit, swap, withdraw) instead of pausing the entire contract at once. It also updates the expected error codes in the tests to reflect the new behavior.

**Test updates for operation-specific pausing:**

* Updated tests to use `client.guard_pause` with `emergency_guard::PauseType` for pausing and unpausing specific operations (DEPOSIT, SWAP, WITHDRAW) instead of the previous `client.set_paused` method. [[1]](diffhunk://#diff-b43772f0aa5267e62cba371950de239057017542da0e0c9c0227bc99a59937feL769-R776) [[2]](diffhunk://#diff-b43772f0aa5267e62cba371950de239057017542da0e0c9c0227bc99a59937feL812-R823) [[3]](diffhunk://#diff-b43772f0aa5267e62cba371950de239057017542da0e0c9c0227bc99a59937feL850-R861) [[4]](diffhunk://#diff-b43772f0aa5267e62cba371950de239057017542da0e0c9c0227bc99a59937feL888-R892)
* Added assertions to verify the paused state for each operation type in `test_pause_and_unpause`.

**Error handling updates:**

* Changed the expected panic error codes in tests from `#14` to `#9` to match the new error handling for operation-specific pausing. [[1]](diffhunk://#diff-b43772f0aa5267e62cba371950de239057017542da0e0c9c0227bc99a59937feL783-R786) [[2]](diffhunk://#diff-b43772f0aa5267e62cba371950de239057017542da0e0c9c0227bc99a59937feL812-R823) [[3]](diffhunk://#diff-b43772f0aa5267e62cba371950de239057017542da0e0c9c0227bc99a59937feL850-R861) [[4]](diffhunk://#diff-b43772f0aa5267e62cba371950de239057017542da0e0c9c0227bc99a59937feL888-R892)

**Minor improvements:**

* Added `vec` to the list of imports from `soroban_sdk` for improved test utility.