### PR TITLE
emergency_guard: publish standardized events and add tests to validate event emission (#228)

### DIFF
--- a/contracts/emergency_guard/src/lib.rs
+++ b/contracts/emergency_guard/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, log, Address, Env, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, log, Address, Env, String, Vec};
 
 /// Granular pause types using bitmask for efficient storage
 /// Each bit represents a different pausable operation
@@ -176,11 +176,10 @@ impl EmergencyGuard {
             .instance()
             .set(&DataKey::PauseState, &pause_state);
 
-        log!(
-            &env,
-            "Pause state updated: op={}, paused={}",
-            operation,
-            paused
+        // Emit standardized EmergencyGuard event
+        env.events().publish(
+            (String::from_str(&env, "emergency_guard.set_pause"), admin.clone()),
+            (operation, paused),
         );
         Ok(())
     }
@@ -196,7 +195,10 @@ impl EmergencyGuard {
             .instance()
             .set(&DataKey::PauseState, &pause_state);
 
-        log!(&env, "Emergency pause all activated");
+        env.events().publish(
+            (String::from_str(&env, "emergency_guard.emergency_pause_all"),),
+            (approvers.clone(),),
+        );
         Ok(())
     }
 
@@ -209,7 +211,10 @@ impl EmergencyGuard {
             .instance()
             .set(&DataKey::PauseState, &pause_state);
 
-        log!(&env, "Resume all activated");
+        env.events().publish(
+            (String::from_str(&env, "emergency_guard.resume_all"),),
+            (approvers.clone(),),
+        );
         Ok(())
     }
 
@@ -221,7 +226,10 @@ impl EmergencyGuard {
         if !admins.iter().any(|a| a == new_admin) {
             admins.push_back(new_admin.clone());
             env.storage().instance().set(&DataKey::Admins, &admins);
-            log!(&env, "Admin added: {}", new_admin);
+            env.events().publish(
+                (String::from_str(&env, "emergency_guard.admin_added"), new_admin.clone()),
+                (),
+            );
         }
 
         Ok(())
@@ -253,7 +261,10 @@ impl EmergencyGuard {
         }
 
         env.storage().instance().set(&DataKey::Admins, &new_admins);
-        log!(&env, "Admin removed: {}", admin);
+        env.events().publish(
+            (String::from_str(&env, "emergency_guard.admin_removed"), admin.clone()),
+            (),
+        );
         Ok(())
     }
 

--- a/contracts/emergency_guard/src/test.rs
+++ b/contracts/emergency_guard/src/test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+use soroban_sdk::{String as SorobanString};
 
 #[test]
 fn test_emergency_guard_initialization() {
@@ -78,4 +79,63 @@ fn test_multiple_pause_types() {
     assert!(!pause.is_paused(crate::PauseType::WITHDRAW));
     assert!(pause.is_paused(crate::PauseType::MINT));
     assert!(!pause.is_paused(crate::PauseType::BURN));
+}
+
+
+#[test]
+fn test_event_emission_for_guard_actions() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let contract_id = e.register(crate::EmergencyGuard, ());
+    let client = crate::EmergencyGuardClient::new(&e, &contract_id);
+
+    // Setup admins
+    let admin1 = Address::random(&e);
+    let admin2 = Address::random(&e);
+    let admins = vec![&e, admin1.clone(), admin2.clone()];
+
+    // Initialize guard
+    client.initialize(&admins, &1u32);
+
+    // Call set_pause
+    client.set_pause(&admin1, &crate::PauseType::TRANSFER, &true).unwrap();
+
+    // Emergency pause all
+    let approvers = vec![&e, admin1.clone()];
+    client.emergency_pause(&approvers).unwrap();
+
+    // Resume all
+    client.resume(&approvers).unwrap();
+
+    // Add admin
+    let new_admin = Address::random(&e);
+    client.add_admin(&approvers, &new_admin).unwrap();
+
+    // Remove admin
+    client.remove_admin(&approvers, &new_admin).unwrap();
+
+    // Inspect events
+    let events = e.events().all();
+
+    // Helper to find events by name
+    let find_events = |name: &str| {
+        let name_val = String::from_str(&e, name);
+        events
+            .iter()
+            .filter(|(_, topics, _)| {
+                if topics.is_empty() {
+                    return false;
+                }
+                let topic_str: Result<SorobanString, _> = topics.get(0).unwrap().try_into_val(&e);
+                topic_str.is_ok() && topic_str.unwrap() == name_val
+            })
+            .collect::<Vec<_>>()
+    };
+
+    assert!(!find_events("emergency_guard.set_pause").is_empty());
+    assert!(!find_events("emergency_guard.emergency_pause_all").is_empty());
+    assert!(!find_events("emergency_guard.resume_all").is_empty());
+    assert!(!find_events("emergency_guard.admin_added").is_empty());
+    assert!(!find_events("emergency_guard.admin_removed").is_empty());
 }


### PR DESCRIPTION
Publishes standardized EmergencyGuard events for pause, emergency pause, resume, and admin add/remove. Adds unit test validating event emission. Fixes #228.