### PR TITLE
docs: document liquidity pool EmergencyGuard controls

### DIFF
--- a/contracts/liquidity_pool/README.md
+++ b/contracts/liquidity_pool/README.md
@@ -1,0 +1,186 @@
+# Liquidity Pool EmergencyGuard Operations
+
+This liquidity pool contract includes EmergencyGuard-style controls for pausing
+pool operations and managing the guard administrator set. The guard is designed
+for emergency response without shutting down unrelated workflows.
+
+## What The Guard Protects
+
+The pool uses a compact `u32` pause bitmask. Each protected operation maps to a
+single bit, so checking whether an operation is paused is constant time and only
+requires reading one pause-state value.
+
+| Operation | Flag | Bit | Protected entry point |
+| --- | --- | --- | --- |
+| Swap | `pause_op::SWAP` | `1 << 0` | `swap` |
+| Deposit | `pause_op::DEPOSIT` | `1 << 1` | `deposit` |
+| Withdraw | `pause_op::WITHDRAW` | `1 << 2` | `withdraw` |
+| Burn | `pause_op::BURN` | `1 << 5` | `burn` |
+| All guard bits | `pause_op::ALL` | `u32::MAX` | Emergency pause and resume |
+
+Granular pausing lets an admin stop the risky path while keeping safer paths
+available. For example, swaps can be paused during a market incident while
+withdrawals stay open.
+
+## Initialization
+
+Calling `initialize(admin, token_a, token_b)` bootstraps the guard with:
+
+- `admin` as the first guard administrator.
+- A multi-signature threshold of `1`.
+- A pause state of `0`, meaning no operations are paused.
+
+The guard state is stored in instance storage:
+
+- `GuardAdmins`: `Vec<Address>`
+- `GuardThreshold`: `u32`
+- `GuardPauseState`: `u32`
+
+## Granular Pause API
+
+Use the dedicated helper functions for the common pool controls:
+
+```rust
+// Pause or resume only swaps.
+pool.pause_swaps();
+pool.resume_swaps();
+
+// Pause or resume only deposits.
+pool.pause_deposits();
+pool.resume_deposits();
+
+// Pause or resume only withdrawals.
+pool.pause_withdrawals();
+pool.resume_withdrawals();
+
+// Pause or resume the core guarded operations at once.
+pool.set_paused(true);
+pool.set_paused(false);
+```
+
+For read-only inspection:
+
+```rust
+let state: u32 = pool.get_pause_state();
+let swaps_paused: bool = pool.is_paused_op(pause_op::SWAP);
+let deposits_paused: bool = pool.is_paused_op(pause_op::DEPOSIT);
+```
+
+## Multi-Sig Admin Operations
+
+Critical guard changes receive an `approvers: Vec<Address>` argument. The
+contract checks unique approvers, confirms they are current guard admins, and
+calls `require_auth()` on each counted approver. The operation succeeds when the
+number of valid approvers is at least `GuardThreshold`.
+
+With the default threshold of `1`, one current guard admin can approve:
+
+```rust
+let approvers = vec![&env, admin.clone()];
+
+pool.emergency_pause_all(approvers.clone());
+pool.resume_all(approvers.clone());
+pool.add_guard_admin(approvers.clone(), new_admin.clone());
+pool.remove_guard_admin(approvers, old_admin.clone());
+```
+
+Duplicate approver addresses do not increase the approval count. Removing an
+admin is rejected when it would reduce the admin count below the current
+threshold.
+
+## Emergency Workflows
+
+### Pause swaps only
+
+Use this when price discovery, oracle input, or routing behavior is suspect but
+liquidity exits should remain available.
+
+```rust
+pool.pause_swaps();
+
+assert!(pool.is_paused_op(pause_op::SWAP));
+assert!(!pool.is_paused_op(pause_op::WITHDRAW));
+```
+
+### Pause deposits only
+
+Use this when new liquidity should be halted while the pool is being reviewed.
+
+```rust
+pool.pause_deposits();
+
+assert!(pool.is_paused_op(pause_op::DEPOSIT));
+assert!(!pool.is_paused_op(pause_op::SWAP));
+```
+
+### Full emergency pause
+
+Use this when the safest response is to block every guarded operation.
+
+```rust
+let approvers = vec![&env, admin.clone()];
+
+pool.emergency_pause_all(approvers);
+
+assert!(pool.is_paused_op(pause_op::SWAP));
+assert!(pool.is_paused_op(pause_op::DEPOSIT));
+assert!(pool.is_paused_op(pause_op::WITHDRAW));
+assert!(pool.is_paused_op(pause_op::BURN));
+```
+
+### Resume after remediation
+
+Only resume after the incident has been investigated and the same approval model
+has authorized the recovery.
+
+```rust
+let approvers = vec![&env, admin.clone()];
+
+pool.resume_all(approvers);
+assert_eq!(pool.get_pause_state(), 0);
+```
+
+## Admin Management
+
+The guard administrator set can be inspected and changed through the pool API.
+
+```rust
+let admins = pool.get_guard_admins();
+let threshold = pool.get_guard_threshold();
+
+let approvers = vec![&env, admin.clone()];
+pool.add_guard_admin(approvers.clone(), new_admin.clone());
+pool.remove_guard_admin(approvers, retired_admin.clone());
+```
+
+Recommended operating model:
+
+- Keep at least two guard admins for production deployments.
+- Use a threshold that matches the incident response policy.
+- Rotate or remove compromised admins before resuming paused operations.
+- Keep an off-chain runbook that maps each admin address to an operator.
+
+## Error Handling
+
+Guarded calls return the pool's `Error` enum:
+
+- `Error::Paused`: the requested operation is currently paused.
+- `Error::Unauthorized`: the caller or approver set is not authorized.
+- `Error::NotInitialized`: guard state has not been initialized.
+
+Callers should treat `Error::Paused` as an expected operational state, not as a
+contract failure. The pause can be cleared by an authorized guard admin workflow.
+
+## Design Notes
+
+The guard path is intentionally lean:
+
+- Pause checks are `O(1)` bit tests against a single `u32`.
+- Pause state uses one compact instance-storage value.
+- Admin and approver validation is linear in the number of supplied addresses,
+  which is appropriate because admin lists are expected to be small.
+- Public helper functions avoid forcing callers to construct bitmasks for common
+  actions such as pausing swaps or deposits.
+
+For the reusable EmergencyGuard contract details, see
+[`../emergency_guard/README.md`](../emergency_guard/README.md).


### PR DESCRIPTION
closes #217 
##Summary of changes:

- Added liquidity pool documentation for EmergencyGuard-style controls.
- Documented granular pause flags for swap, deposit, withdraw, burn, and full emergency pause.
- Added usage guidance for multi-sig approver workflows, admin management, emergency response, and error handling.

##Reason for the changes:
This updates the liquidity pool documentation for issue #217 so maintainers and integrators understand how to use the new multi-sig and granular pause features safely.