### PR TITLE
Feature/wasm metadata frontend 200

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ members = [
     "contracts/proxy",
     "contracts/flash_loan_vault",
     "contracts/staking_rewards",
+    "contracts/cross_chain_verifier",
 ]

--- a/contracts/cross_chain_verifier/Cargo.toml
+++ b/contracts/cross_chain_verifier/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cross-chain-verifier"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/cross_chain_verifier/src/lib.rs
+++ b/contracts/cross_chain_verifier/src/lib.rs
@@ -1,0 +1,89 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Vec, Bytes};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Admin,
+    StateRoot(u32), // block height mapped to state root
+}
+
+#[contract]
+pub struct CrossChainVerifier;
+
+#[contractimpl]
+impl CrossChainVerifier {
+    /// Initialize the contract with an admin who has the right to update state roots.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Update the state root for a specific block height.
+    /// Only the admin (relayer network) can perform this action.
+    pub fn update_root(env: Env, block_height: u32, new_root: BytesN<32>) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        
+        env.storage().persistent().set(&DataKey::StateRoot(block_height), &new_root);
+    }
+
+    /// Retrieve a stored state root by block height.
+    pub fn get_root(env: Env, block_height: u32) -> Option<BytesN<32>> {
+        env.storage().persistent().get(&DataKey::StateRoot(block_height))
+    }
+
+    /// Verifies a Binary Merkle Tree proof.
+    /// In a cross-chain context, this allows proving that a specific message or transaction
+    /// (the `leaf`) was included in the block matching `block_height` state root.
+    /// 
+    /// * `block_height`: The block height of the state root to verify against.
+    /// * `leaf`: The hash of the cross-chain message to be verified.
+    /// * `proof`: A list of sibling hashes forming the Merkle proof.
+    /// * `proof_flags`: A list of booleans indicating if the sibling is on the left (true) or right (false).
+    pub fn verify_message(
+        env: Env,
+        block_height: u32,
+        leaf: BytesN<32>,
+        proof: Vec<BytesN<32>>,
+        proof_flags: Vec<bool>,
+    ) -> bool {
+        let expected_root: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StateRoot(block_height))
+            .unwrap_or_else(|| panic!("State root not found"));
+
+        if proof.len() != proof_flags.len() {
+            panic!("Invalid proof format");
+        }
+
+        let mut current_hash = leaf.to_array();
+
+        for i in 0..proof.len() {
+            let sibling = proof.get(i).unwrap().to_array();
+            let is_left_sibling = proof_flags.get(i).unwrap();
+
+            let mut combined = [0u8; 64];
+            if is_left_sibling {
+                combined[0..32].copy_from_slice(&sibling);
+                combined[32..64].copy_from_slice(&current_hash);
+            } else {
+                combined[0..32].copy_from_slice(&current_hash);
+                combined[32..64].copy_from_slice(&sibling);
+            }
+            
+            // Compute sha256 of the combined 64 bytes
+            let combined_bytes = Bytes::from_slice(&env, &combined);
+            current_hash = env.crypto().sha256(&combined_bytes).to_array();
+        }
+
+        let computed_root = BytesN::from_array(&env, &current_hash);
+        computed_root == expected_root
+    }
+}
+
+mod test;

--- a/contracts/cross_chain_verifier/src/test.rs
+++ b/contracts/cross_chain_verifier/src/test.rs
@@ -1,0 +1,108 @@
+#![cfg(test)]
+
+use crate::{CrossChainVerifier, CrossChainVerifierClient};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, Vec, Bytes};
+
+#[test]
+fn test_initialization() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, CrossChainVerifier);
+    let client = CrossChainVerifierClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_double_initialization() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, CrossChainVerifier);
+    let client = CrossChainVerifierClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.initialize(&admin); // Should panic
+}
+
+#[test]
+fn test_root_update() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, CrossChainVerifier);
+    let client = CrossChainVerifierClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let root = BytesN::from_array(&env, &[1; 32]);
+    let block_height = 100;
+
+    client.update_root(&block_height, &root);
+
+    let retrieved = client.get_root(&block_height).unwrap();
+    assert_eq!(retrieved, root);
+}
+
+#[test]
+fn test_verify_message_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, CrossChainVerifier);
+    let client = CrossChainVerifierClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let leaf = BytesN::from_array(&env, &[2; 32]);
+    let sibling1 = BytesN::from_array(&env, &[3; 32]);
+    let sibling2 = BytesN::from_array(&env, &[4; 32]);
+
+    // Manually construct the root
+    // Level 1: Hash(sibling1 || leaf) since proof_flags = true (left sibling)
+    let mut combined_1 = [0u8; 64];
+    combined_1[0..32].copy_from_slice(&sibling1.to_array());
+    combined_1[32..64].copy_from_slice(&leaf.to_array());
+    let hash_1 = env.crypto().sha256(&Bytes::from_slice(&env, &combined_1)).to_array();
+
+    // Level 2: Hash(hash_1 || sibling2) since proof_flags = false (right sibling)
+    let mut combined_2 = [0u8; 64];
+    combined_2[0..32].copy_from_slice(&hash_1);
+    combined_2[32..64].copy_from_slice(&sibling2.to_array());
+    let final_root = env.crypto().sha256(&Bytes::from_slice(&env, &combined_2)).to_array();
+
+    let expected_root_bytes = BytesN::from_array(&env, &final_root);
+
+    let block_height = 100;
+    client.update_root(&block_height, &expected_root_bytes);
+
+    let mut proof = Vec::new(&env);
+    proof.push_back(sibling1);
+    proof.push_back(sibling2);
+
+    let mut proof_flags = Vec::new(&env);
+    proof_flags.push_back(true);  // left
+    proof_flags.push_back(false); // right
+
+    let result = client.verify_message(&block_height, &leaf, &proof, &proof_flags);
+    assert!(result);
+}
+
+#[test]
+#[should_panic(expected = "State root not found")]
+fn test_verify_message_no_root() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, CrossChainVerifier);
+    let client = CrossChainVerifierClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let leaf = BytesN::from_array(&env, &[2; 32]);
+    let proof = Vec::new(&env);
+    let proof_flags = Vec::new(&env);
+
+    client.verify_message(&100, &leaf, &proof, &proof_flags);
+}

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["cdylib"]
 emergency_guard = { path = "../emergency_guard" }
 soroban-sdk = "22.0.0"
 # Emergency guard provides standardized pause and admin management capabilities
-emergency_guard = { path = "../emergency_guard" }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/web/components/upload-zone.tsx
+++ b/web/components/upload-zone.tsx
@@ -189,33 +189,51 @@ export function UploadZone({ onFileReady }: UploadZoneProps) {
       setUploadState('scanning');
       setErrorMessage('');
 
-      // Simulate async scan (replace with real WASM parsing logic)
       const reader = new FileReader();
-      reader.onload = () => {
+      reader.onload = (event) => {
         setTimeout(() => {
           try {
+            const arrayBuffer = event.target?.result as ArrayBuffer;
+            if (!arrayBuffer) throw new Error('Failed to read file content');
+
+            if (arrayBuffer.byteLength < 8) {
+              throw new Error('File is too small to be a valid WebAssembly module');
+            }
+
+            const view = new DataView(arrayBuffer);
+            
+            const magicNumber = view.getUint32(0, false);
+            if (magicNumber !== 0x0061736d) {
+              throw new Error('Invalid WASM magic number. File is not a valid WebAssembly module');
+            }
+
+            const version = view.getUint32(4, true);
+            if (version !== 1) {
+              throw new Error(`Unsupported WASM version: ${version}. Expected version 1`);
+            }
+
             setUploadState('success');
             onFileReady?.(file);
           } catch (error) {
-            setUnexpectedError(
-              error instanceof Error
-                ? error
-                : new Error('Unexpected upload callback failure')
-            );
+            setErrorMessage(error instanceof Error ? error.message : 'Failed to parse WASM metadata');
+            setUploadState('error');
+            setDroppedFile(null);
           }
-        }, 2000); // 2-second scan window
+        }, 800);
       };
+      
       reader.onerror = () => {
-        const message = reader.error?.message ?? 'Unable to read the selected file';
-        setUnexpectedError(new Error(message));
+        setErrorMessage(reader.error?.message ?? 'Unable to read the selected file');
+        setUploadState('error');
+        setDroppedFile(null);
       };
 
       try {
         reader.readAsArrayBuffer(file);
       } catch (error) {
-        setUnexpectedError(
-          error instanceof Error ? error : new Error('Unable to start reading the selected file')
-        );
+        setErrorMessage(error instanceof Error ? error.message : 'Unable to start reading the selected file');
+        setUploadState('error');
+        setDroppedFile(null);
       }
     },
     [onFileReady]


### PR DESCRIPTION
## Overview
This PR implements frontend and smart contract enhancements addressing two key feature requests: frontend WASM metadata validation and the foundation for a Soroban cross-chain message verifier (light client).

## Changes Made

### 1. Frontend WASM Metadata Validation (#200)
- **Implemented Binary Parsing**: Replaced mock validation logic in `web/components/upload-zone.tsx` with native `ArrayBuffer` parsing using the `FileReader` API.
- **Header Validation**: 
  - Validates the standard WebAssembly Magic Number (`\0asm` / `0x0061736d`).
  - Validates the WASM version (checks for standard version `1`).
- **Improved Error Handling**: Introduced strong type-checking and proper error captures during the buffer parsing phase to gracefully reflect file rejection in the UI.

### 2. Cross-Chain Message Verifier (Light Client) (#129)
- **New Contract (`cross_chain_verifier`)**: Introduced a new Rust Soroban smart contract under `/contracts/cross_chain_verifier`.
- **State Root Tracking**: 
  - Added an admin-restricted capability to store and track cross-chain state roots mapped to specific block heights (`update_root`, `get_root`).
- **Binary Merkle Tree Verification**:
  - Implemented the core logic to authenticate arbitrary cross-chain payload hashes against stored state roots directly on Soroban (`verify_message`).
  - Supports traversing a provided sibling path and computing the root dynamically using the SDK's native `sha256` utilities.
- **Test Suite**: Added a robust suite covering mock environments, root tracking, and positive/negative path verifications.
- **Workspace Sync**: Resolved a pre-existing duplicate dependency issue in `token/Cargo.toml` to restore reliable cargo tests and builds.

## Verification
- **Frontend**: From the `web` directory, start the app and drag a compiled `.wasm` file (and a fake `.wasm` text file) into the dropzone. It should instantly recognize valid files via the magic number and reject invalid ones.
- **Contracts**: Run `cargo test --package cross-chain-verifier` to verify that all cryptographic validation logic successfully passes on Soroban.

## Related Issues


Closes #200 
Closes #129 