### PR TITLE
Fix/300 mobile responsive dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cross-chain-verifier"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/web/components/NutritionLabel.tsx
+++ b/web/components/NutritionLabel.tsx
@@ -82,9 +82,9 @@ export const NutritionLabel: React.FC<NutritionLabelProps> = ({
     };
 
     return (
-        <div className="bg-[#161b22] border border-[#30363d] rounded-lg p-6 font-mono">
-            <div className="border-b-2 border-[#30363d] pb-2 mb-4 flex justify-between items-end">
-                <h2 className="text-2xl font-black text-[#c9d1d9] uppercase tracking-wider">Nutrition Facts</h2>
+        <div className="bg-[#161b22] border border-[#30363d] rounded-lg p-4 sm:p-6 font-mono">
+            <div className="border-b-2 border-[#30363d] pb-2 mb-4 flex flex-wrap justify-between items-end gap-2">
+                <h2 className="text-xl sm:text-2xl font-black text-[#c9d1d9] uppercase tracking-wider">Nutrition Facts</h2>
                 <span className="text-xs text-[#8b949e]">Per Transaction</span>
             </div>
 

--- a/web/components/Resultviewer.tsx
+++ b/web/components/Resultviewer.tsx
@@ -49,7 +49,7 @@ export function ResultViewer({ result }: ResultViewerProps) {
         border: `1px solid #30363d`,
       }}
     >
-      <div style={{ marginBottom: '16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div style={{ marginBottom: '16px', display: 'flex', flexWrap: 'wrap', gap: '12px', justifyContent: 'space-between', alignItems: 'center' }}>
         <div>
           <h3
             style={{

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -77,19 +77,8 @@ export default function Home() {
   return (
     <div style={{ minHeight: '100vh', backgroundColor: '#0f1117' }}>
       {/* Header */}
-      <header
-        style={{
-          backgroundColor: '#1a1f26',
-          borderBottom: '1px solid #30363d',
-          padding: '24px 0',
-          position: 'sticky',
-          top: 0,
-          zIndex: 100,
-          display: 'flex',
-          justifyContent: 'space-between'
-        }}
-      >
-        <div style={{ maxWidth: '1200px', paddingLeft: '140px' }}>
+      <header className="sticky top-0 z-[100] flex flex-col gap-4 border-b border-[#30363d] bg-[#1a1f26] px-6 py-6 sm:flex-row sm:items-center sm:justify-between sm:px-10 lg:pl-[140px] lg:pr-[125px]">
+        <div className="max-w-[1200px]">
           <h1 style={{ margin: '0 0 12px 0', fontSize: '28px', fontWeight: '700', color: '#00d9ff', letterSpacing: '0.5px' }}>
             SoroScope
           </h1>
@@ -98,14 +87,14 @@ export default function Home() {
           </p>
         </div>
 
-        {/* Wallet Connection in Top-Right */}
-        <div className="pr-[125px]">
+        {/* Wallet Connection */}
+        <div>
           <ConnectButton />
         </div>
       </header>
 
       {/* Main Content */}
-      <main style={{ maxWidth: '1200px', margin: '0 auto', padding: '24px' }}>
+      <main className="mx-auto max-w-[1200px] px-4 py-6 sm:px-6">
 
         {/* WASM Upload Zone */}
         <div
@@ -186,7 +175,7 @@ export default function Home() {
           </p>
         </div>
 
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px', marginBottom: '24px' }}>
+        <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
           {/* Left Column - Function Selection & Form */}
           <div>
             <FunctionSidebar


### PR DESCRIPTION
## Summary
 The analysis dashboard didn't render correctly on mobile
viewports — the resource panels and gas table were squeezed into half the
screen and the header overflowed horizontally.

Root cause: the function/results layout used a hardcoded inline
`gridTemplateColumns: '1fr 1fr'` that never collapsed, and the header used
fixed `140px`/`125px` paddings that overflowed narrow screens.

## Changes

- **Dashboard grid** stacks into a single column below `lg`
  (`grid-cols-1 lg:grid-cols-2`) so the resource heatmap panels and the gas
  table get full width on phones.
- **Header** now wraps and uses responsive padding instead of the fixed
  140px/125px offsets.
- **Main container** uses responsive horizontal padding.
- **NutritionLabel** (gas table) header wraps with a gap; title and padding
  scale down on mobile so "Nutrition Facts" / "Per Transaction" no longer
  collide.
- **ResultViewer** header row wraps so the "Download State Snapshot" button
  drops below the title instead of overflowing.

## Extra commit (CI unblock)

`chore: add cross-chain-verifier to Cargo.lock` — the `cross_chain_verifier`
contract (#129) was added as a workspace member but the lockfile was never
regenerated, so `cargo clippy --locked` and `cargo test --locked` (both used
in CI) fail on every PR with an out-of-date lock. Regenerating fixes the
Rust CI jobs. Drop this commit if you'd prefer a frontend-only PR.

## Testing

- Verified the lockfile fix: committed `Cargo.lock` fails `cargo metadata
  --locked`; regenerated lockfile passes.
- Frontend lint not run locally (no network for `npm ci`); changes are
  className/inline-style only, so no eslint-config-next rules are affected.


Closes: #300 
Closes: #319 