### PR TITLE
ci: add GitHub Actions workflow for Soroban Testnet deployment (#337)

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -1,0 +1,217 @@
+name: Deploy Contracts to Testnet
+
+# Triggers after the CI workflow succeeds on main, or manually via the Actions UI.
+on:
+  workflow_run:
+    workflows: ["SoroScope CI"]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: testnet-deploy
+  cancel-in-progress: false   # queue, don't cancel an in-flight deployment
+
+env:
+  CARGO_TERM_COLOR: always
+  STELLAR_NETWORK: testnet
+  STELLAR_RPC_URL: https://soroban-testnet.stellar.org
+  STELLAR_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+
+jobs:
+  deploy:
+    name: Deploy to Soroban Testnet
+    runs-on: ubuntu-latest
+    # Skip if triggered by a failed CI run (unless force-dispatched manually).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+
+    steps:
+      # ------------------------------------------------------------------ #
+      # Checkout                                                             #
+      # ------------------------------------------------------------------ #
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          # When triggered by workflow_run, deploy the exact commit that passed CI.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      # ------------------------------------------------------------------ #
+      # Rust toolchain                                                       #
+      # ------------------------------------------------------------------ #
+      - name: Install Rust (stable + wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-testnet-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-testnet-
+
+      # ------------------------------------------------------------------ #
+      # System & CLI dependencies                                            #
+      # ------------------------------------------------------------------ #
+      - name: Install system libraries
+        run: sudo apt-get update -qq && sudo apt-get install -y pkg-config libdbus-1-dev libudev-dev
+
+      - name: Install Stellar CLI (soroban-cli v22)
+        run: |
+          if ! command -v stellar &>/dev/null; then
+            cargo install soroban-cli --version 22.0.0 --locked
+          fi
+
+      # ------------------------------------------------------------------ #
+      # Deployer identity                                                    #
+      # Required GitHub secret: TESTNET_DEPLOYER_SECRET_KEY                 #
+      #   A Stellar secret key (starts with 'S') for a testnet account.     #
+      # ------------------------------------------------------------------ #
+      - name: Configure deployer identity
+        env:
+          TESTNET_SECRET_KEY: ${{ secrets.TESTNET_DEPLOYER_SECRET_KEY }}
+        run: |
+          printf '%s\n' "$TESTNET_SECRET_KEY" | stellar keys add deployer --secret-key
+          DEPLOYER_ADDRESS=$(stellar keys address deployer)
+          echo "DEPLOYER_ADDRESS=${DEPLOYER_ADDRESS}" >> "$GITHUB_ENV"
+          echo "Deployer public key: ${DEPLOYER_ADDRESS}"
+
+      - name: Fund deployer account via Friendbot
+        run: |
+          # Friendbot will create the account if it does not exist yet.
+          # If the account already exists it returns an error, which is harmless.
+          RESPONSE=$(curl -sf "https://friendbot.stellar.org/?addr=${DEPLOYER_ADDRESS}" 2>&1) \
+            && echo "Account funded: ${DEPLOYER_ADDRESS}" \
+            || echo "Friendbot skipped (account already funded — continuing)"
+
+      # ------------------------------------------------------------------ #
+      # Build                                                                #
+      # stellar contract build compiles only cdylib crates in the workspace #
+      # to wasm32-unknown-unknown, skipping the core binary crate.          #
+      # ------------------------------------------------------------------ #
+      - name: Build all contracts
+        run: stellar contract build
+
+      # ------------------------------------------------------------------ #
+      # Deploy                                                               #
+      # ------------------------------------------------------------------ #
+      - name: Deploy contracts to Soroban Testnet
+        id: deploy
+        run: |
+          set -euo pipefail
+
+          WASM_DIR="target/wasm32-unknown-unknown/release"
+          MANIFEST="deployment_manifest.txt"
+
+          # Ordered list of deployable contract WASM names.
+          # emergency_guard is first because other contracts reference it at runtime.
+          # error_codes and proxy are rlib-only and produce no WASM artifact.
+          CONTRACTS=(
+            "emergency_guard"
+            "soroscope_math"
+            "soroban_token_contract"
+            "liquidity_pool"
+            "soroban_liquidity_pool_factory_contract"
+            "cpu_heavy"
+            "storage_heavy"
+            "cross_call"
+            "cross_chain_verifier"
+            "hello_soroban"
+            "flash_loan_vault"
+            "soroban_staking_rewards"
+            "soroban_typed_data_auth_contract"
+          )
+
+          {
+            echo "# SoroScope Testnet Deployment"
+            echo "# Timestamp : $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+            echo "# Commit    : ${GITHUB_SHA}"
+            echo "# Network   : Soroban Testnet"
+            echo "# Deployer  : ${DEPLOYER_ADDRESS}"
+            echo ""
+          } > "$MANIFEST"
+
+          FAILED=0
+
+          for name in "${CONTRACTS[@]}"; do
+            wasm="${WASM_DIR}/${name}.wasm"
+
+            if [ ! -f "$wasm" ]; then
+              echo "::warning::${name}.wasm not found — skipping"
+              echo "${name}=NOT_BUILT" >> "$MANIFEST"
+              continue
+            fi
+
+            echo "Deploying ${name}..."
+
+            contract_id=$(stellar contract deploy \
+              --wasm "$wasm" \
+              --source deployer \
+              --network testnet \
+              --fee 1000000) || {
+              echo "::error::Deploy failed for ${name}"
+              echo "${name}=DEPLOY_FAILED" >> "$MANIFEST"
+              FAILED=$((FAILED + 1))
+              continue
+            }
+
+            echo "  → ${contract_id}"
+            echo "${name}=${contract_id}" >> "$MANIFEST"
+          done
+
+          echo ""
+          echo "=== Deployment Manifest ==="
+          cat "$MANIFEST"
+
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::${FAILED} contract(s) failed to deploy — see log for details"
+            exit 1
+          fi
+
+      # ------------------------------------------------------------------ #
+      # Artifacts & summary                                                  #
+      # ------------------------------------------------------------------ #
+      - name: Upload deployment manifest
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: testnet-deployment-${{ github.sha }}
+          path: deployment_manifest.txt
+          retention-days: 90
+
+      - name: Write job summary
+        if: always()
+        run: |
+          MANIFEST="deployment_manifest.txt"
+          [ -f "$MANIFEST" ] || exit 0
+
+          REF="${{ github.event.workflow_run.head_sha || github.sha }}"
+
+          {
+            echo "## Soroban Testnet Deployment"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Commit** | \`${REF}\` |"
+            echo "| **Network** | Soroban Testnet |"
+            echo "| **RPC** | ${STELLAR_RPC_URL} |"
+            echo "| **Deployer** | \`${DEPLOYER_ADDRESS:-unknown}\` |"
+            echo ""
+            echo "### Contract IDs"
+            echo ""
+            echo "| Contract | Contract ID |"
+            echo "|----------|-------------|"
+            while IFS='=' read -r name id; do
+              [[ "$name" == "#"* || -z "$name" ]] && continue
+              echo "| \`${name}\` | \`${id}\` |"
+            done < "$MANIFEST"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
PR #337 Testnet: Setup Github Actions CI/CD for testnet deployment

- Adds `.github/workflows/deploy-testnet.yml` — a dedicated GitHub Actions workflow that automates deployment of the full Soroban contract suite to the Soroban Testnet on every merge to `main`.
- Workflow triggers via `workflow_run` after **SoroScope CI** passes, ensuring broken code is never deployed. Also supports manual dispatch from the Actions UI.
- A `concurrency` guard queues simultaneous deployments instead of cancelling them, preventing race conditions.
- Deploys all **13 cdylib contracts** in dependency order (`emergency_guard` first, then contracts that depend on it).
- Records every deployed contract ID in a `deployment_manifest.txt` artifact retained for **90 days**.
- Writes a formatted summary table (contract name → contract ID) directly to the GitHub Actions job summary page.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/deploy-testnet.yml` | New — testnet deployment workflow |

## How it works

1. **Trigger** — fires after `SoroScope CI` completes on `main` with a `success` conclusion, or manually via `workflow_dispatch`.
2. **Build** — runs `stellar contract build` which compiles only `cdylib` workspace crates to `wasm32-unknown-unknown`, skipping the `core` binary and `rlib`-only crates (`error_codes`, `proxy`).
3. **Identity** — loads the deployer Stellar secret key from the `TESTNET_DEPLOYER_SECRET_KEY` GitHub Actions secret and derives the public key.
4. **Funding** — calls Friendbot to fund the deployer account on first run; gracefully skips if the account already exists.
5. **Deploy** — iterates through all 13 contracts, calls `stellar contract deploy --network testnet` for each, and records the returned contract ID.
6. **Report** — uploads `deployment_manifest.txt` as a workflow artifact and renders a contract ID table in the Actions job summary.

## Required setup

Add one GitHub Actions secret before merging:

| Secret | Description |
|--------|-------------|
| `TESTNET_DEPLOYER_SECRET_KEY` | A Stellar secret key (`S…`) for a funded testnet account |

Generate a keypair locally with `stellar keys generate --no-fund deployer` and copy the secret key. Friendbot will fund the account automatically on the first workflow run.

## Test plan

- [ ] Add `TESTNET_DEPLOYER_SECRET_KEY` secret to the repository
- [ ] Merge this PR and confirm `SoroScope CI` triggers `Deploy Contracts to Testnet` automatically
- [ ] Verify all 13 contract IDs appear in the Actions job summary
- [ ] Download the `testnet-deployment-<sha>` artifact and confirm `deployment_manifest.txt` is populated
- [ ] Trigger a manual run via `workflow_dispatch` and confirm it deploys successfully
- [ ] Confirm a second push does not run two deployments simultaneously (concurrency queue)

Closes #337 
