### PR TITLE
Update admin functions to use new multi-sig authorization flow

### DIFF
--- a/contracts/emergency_guard/src/lib.rs
+++ b/contracts/emergency_guard/src/lib.rs
@@ -309,6 +309,11 @@ impl EmergencyGuard {
             .unwrap_or(0)
     }
 
+    /// Authorize administration operations by verifying the caller approvers against the guard threshold.
+    pub fn authorize(env: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
+        Self::check_multi_sig(&env, &approvers)
+    }
+
     // Internal helpers
 
     fn is_admin_internal(env: &Env, addr: &Address) -> bool {

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -8,7 +8,9 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+emergency_guard = { path = "../emergency_guard" }
 soroban-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+emergency_guard = { path = "../emergency_guard" }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+use emergency_guard::EmergencyGuard;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, String,
 };
@@ -99,7 +100,11 @@ fn require_admin(env: &Env) -> Result<Address, Error> {
         .instance()
         .get(&DataKey::Admin)
         .ok_or(Error::NotInitialized)?;
-    admin.require_auth();
+
+    let mut approvers: Vec<Address> = Vec::new(env);
+    approvers.push_back(admin.clone());
+    EmergencyGuard::authorize(env.clone(), approvers).map_err(|_| Error::Unauthorized)?;
+
     Ok(admin)
 }
 
@@ -166,6 +171,12 @@ impl GovernanceContract {
             .instance()
             .set(&DataKey::IdentityRequired, &identity_required);
         env.storage().instance().set(&DataKey::NextProposalId, &0u32);
+
+        let mut admins: Vec<Address> = Vec::new(&env);
+        admins.push_back(admin.clone());
+        EmergencyGuard::initialize(env.clone(), admins, 1)
+            .map_err(|_| Error::Unauthorized)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
This PR updates governance admin authorization to use the shared EmergencyGuard multi-sig flow and exposes a reusable `authorize` helper.

Closes #303