### PR TITLE
feat: add clear analysis button to reset analysis state and upload zone

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -266,6 +266,19 @@ export default function Home() {
                 <>
                   <ResultViewer result={currentResult} />
                   {currentResult?.resourceCost && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setCurrentResult(null);
+                        const resetBtn = document.getElementById('wasm-upload-reset-btn');
+                        if (resetBtn) resetBtn.click();
+                      }}
+                      className="mt-4 px-4 py-2 bg-slate-800 text-slate-300 rounded hover:bg-slate-700 transition"
+                    >
+                      Clear analysis
+                    </button>
+                  )}
+                  {currentResult?.resourceCost && (
                     <div className="mt-4">
                       <NutritionLabel
                         cpu_instructions={currentResult.resourceCost.cpu_instructions}


### PR DESCRIPTION
This pr closes #299 

This change introduces a clear analysis action that lets users reset the current WASM analysis results and return to the upload screen in a single click.

Key Updates

Explorer Tab (pages/index.tsx)
Added a “Clear analysis” button that appears when a successful