### PR TITLE
Feat:( Contracts) Implement nonce management for cross-chain messages

### DIFF
--- a/contracts/cross_chain_verifier/src/lib.rs
+++ b/contracts/cross_chain_verifier/src/lib.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{contract, contractimpl, contracttype, Address, BytesN, Env, Ve
 pub enum DataKey {
     Admin,
     StateRoot(u32), // block height mapped to state root
+    ProcessedNonce(u64), // track consumed nonces for replay protection
 }
 
 #[contract]
@@ -83,6 +84,43 @@ impl CrossChainVerifier {
 
         let computed_root = BytesN::from_array(&env, &current_hash);
         computed_root == expected_root
+    }
+
+    /// Verify a cross-chain message and mark the provided nonce as consumed.
+    /// This prevents the same nonce from being processed twice.
+    pub fn verify_message_and_consume(
+        env: Env,
+        block_height: u32,
+        nonce: u64,
+        leaf: BytesN<32>,
+        proof: Vec<BytesN<32>>,
+        proof_flags: Vec<bool>,
+    ) -> bool {
+        if Self::is_nonce_processed(env.clone(), nonce) {
+            panic!("nonce already processed");
+        }
+
+        let valid = Self::verify_message(env.clone(), block_height, leaf, proof, proof_flags);
+        if !valid {
+            return false;
+        }
+
+        Self::consume_nonce(&env, nonce);
+        true
+    }
+
+    /// Returns true if the nonce has already been consumed.
+    pub fn is_nonce_processed(env: Env, nonce: u64) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ProcessedNonce(nonce))
+            .unwrap_or(false)
+    }
+
+    fn consume_nonce(env: &Env, nonce: u64) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProcessedNonce(nonce), &true);
     }
 }
 

--- a/contracts/cross_chain_verifier/src/test.rs
+++ b/contracts/cross_chain_verifier/src/test.rs
@@ -91,6 +91,89 @@ fn test_verify_message_success() {
 }
 
 #[test]
+fn test_verify_message_and_consume_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, CrossChainVerifier);
+    let client = CrossChainVerifierClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let leaf = BytesN::from_array(&env, &[2; 32]);
+    let sibling1 = BytesN::from_array(&env, &[3; 32]);
+    let sibling2 = BytesN::from_array(&env, &[4; 32]);
+
+    let mut combined_1 = [0u8; 64];
+    combined_1[0..32].copy_from_slice(&sibling1.to_array());
+    combined_1[32..64].copy_from_slice(&leaf.to_array());
+    let hash_1 = env.crypto().sha256(&Bytes::from_slice(&env, &combined_1)).to_array();
+
+    let mut combined_2 = [0u8; 64];
+    combined_2[0..32].copy_from_slice(&hash_1);
+    combined_2[32..64].copy_from_slice(&sibling2.to_array());
+    let final_root = env.crypto().sha256(&Bytes::from_slice(&env, &combined_2)).to_array();
+
+    let expected_root_bytes = BytesN::from_array(&env, &final_root);
+    let block_height = 100;
+    client.update_root(&block_height, &expected_root_bytes);
+
+    let mut proof = Vec::new(&env);
+    proof.push_back(sibling1);
+    proof.push_back(sibling2);
+
+    let mut proof_flags = Vec::new(&env);
+    proof_flags.push_back(true);
+    proof_flags.push_back(false);
+
+    assert!(client.verify_message_and_consume(&block_height, &1u64, &leaf, &proof, &proof_flags));
+    assert!(client.is_nonce_processed(&1u64));
+}
+
+#[test]
+#[should_panic(expected = "nonce already processed")]
+fn test_replay_nonce_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, CrossChainVerifier);
+    let client = CrossChainVerifierClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let leaf = BytesN::from_array(&env, &[2; 32]);
+    let sibling1 = BytesN::from_array(&env, &[3; 32]);
+    let sibling2 = BytesN::from_array(&env, &[4; 32]);
+
+    let mut combined_1 = [0u8; 64];
+    combined_1[0..32].copy_from_slice(&sibling1.to_array());
+    combined_1[32..64].copy_from_slice(&leaf.to_array());
+    let hash_1 = env.crypto().sha256(&Bytes::from_slice(&env, &combined_1)).to_array();
+
+    let mut combined_2 = [0u8; 64];
+    combined_2[0..32].copy_from_slice(&hash_1);
+    combined_2[32..64].copy_from_slice(&sibling2.to_array());
+    let final_root = env.crypto().sha256(&Bytes::from_slice(&env, &combined_2)).to_array();
+
+    let expected_root_bytes = BytesN::from_array(&env, &final_root);
+    let block_height = 100;
+    client.update_root(&block_height, &expected_root_bytes);
+
+    let mut proof = Vec::new(&env);
+    proof.push_back(sibling1);
+    proof.push_back(sibling2);
+
+    let mut proof_flags = Vec::new(&env);
+    proof_flags.push_back(true);
+    proof_flags.push_back(false);
+
+    assert!(client.verify_message_and_consume(&block_height, &1u64, &leaf, &proof, &proof_flags));
+    client.verify_message_and_consume(&block_height, &1u64, &leaf, &proof, &proof_flags);
+}
+
+#[test]
 #[should_panic(expected = "State root not found")]
 fn test_verify_message_no_root() {
     let env = Env::default();


### PR DESCRIPTION

## Changes implemented

- Updated lib.rs
  - Added `DataKey::ProcessedNonce(u64)` to track consumed nonces.
  - Added `verify_message_and_consume(...)` to verify a cross-chain leaf and then mark its nonce as consumed.
  - Added `is_nonce_processed(...)` to query replay state.
  - Added internal `consume_nonce(...)` helper.
  - Existing proof verification remains unchanged and is reused.

- Updated test.rs
  - Added coverage for successful nonce consumption.
  - Added replay protection test that panics when the same nonce is reused.

## Validation

- `get_errors` reports no diagnostics in:
  - lib.rs
  - test.rs

closes #325