### PR TITLE
docs/ci: address issues #497, #500, #503, #504

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,23 @@ env:
 
 jobs:
   # ------------------------------------------------------------------
+  # Job 0: Cargo Check (fast compile check for all targets)
+  # ------------------------------------------------------------------
+  check:
+    name: Cargo Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: wasm32-unknown-unknown
+      - name: Install System Dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libdbus-1-dev libudev-dev
+      - name: Cargo Check
+        run: cargo check --locked --all-targets
+
+  # ------------------------------------------------------------------
   # Job 1: Formatter Check (Rust)
   # ------------------------------------------------------------------
   fmt:

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ From the **repo root**:
   npm run lint
   ```
 
-(Add CI in `./.github/workflows` to automate these.)
+These checks run automatically on every push and pull request via the CI pipeline in `.github/workflows/ci.yml` (`cargo check`, `cargo fmt`, `cargo clippy`, `cargo test`, and frontend lint).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,47 @@ RUST_LOG=info cargo run -p soroscope-core
 
 The server listens on `http://localhost:8080` by default.
 
+### Merkle Tree Utility
+
+The core crate includes an off-chain Merkle Tree utility (`core/src/merkle_tree.rs`) for building binary Merkle trees and generating inclusion proofs compatible with the `cross_chain_verifier` contract.
+
+**Build a tree and get the root:**
+
+```bash
+# Run your script that calls MerkleTree::build() and prints the root hex
+ROOT=$(cargo run --example build_tree -- --block 1000)
+
+# Post the root on-chain
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source relayer \
+  --network testnet \
+  -- update_root \
+  --block_height 1000 \
+  --new_root "$ROOT"
+```
+
+**Verify a proof on-chain:**
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  -- verify_message \
+  --block_height 1000 \
+  --leaf "<leaf_hex>" \
+  --proof '["<sibling_hex>"]' \
+  --proof_flags '[true]'
+```
+
+**Run Merkle Tree tests:**
+
+```bash
+cargo test -p soroscope-core merkle_tree
+```
+
+See [`core/MERKLE_TREE_README.md`](./core/MERKLE_TREE_README.md) for full API reference, proof generation examples, and the complete relayer pipeline.
+
 ---
 
 ## 🌐 Web Dashboard (`/web`)

--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -1,0 +1,194 @@
+# Mainnet Release — Deployment Guide & CLI Installation
+
+This guide covers installing the SoroScope CLI, running a local simulation, and preparing for Stellar Mainnet deployment.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Rust (stable) | ≥ 1.75 | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
+| wasm32 target | — | `rustup target add wasm32-unknown-unknown` |
+| Stellar CLI | 22.x | `cargo install soroban-cli --version 22.0.0 --locked` |
+| Node.js | ≥ 18 | [nodejs.org](https://nodejs.org) |
+
+---
+
+## CLI Installation
+
+### From Source (Recommended)
+
+```bash
+git clone https://github.com/SoroLabs/soroscope
+cd soroscope
+
+# Build the core CLI binary
+cargo build --release -p soroscope-core
+
+# The binary is at:
+./target/release/soroscope-core
+```
+
+To make it available system-wide:
+
+```bash
+cp target/release/soroscope-core /usr/local/bin/soroscope
+soroscope --help
+```
+
+### Verify the Build
+
+```bash
+cargo check --locked --all-targets
+cargo test --locked
+```
+
+---
+
+## Running a Local Simulation
+
+The core server exposes an HTTP API on `http://localhost:8080` for profiling contract resource usage.
+
+### Start the Server
+
+```bash
+RUST_LOG=info cargo run -p soroscope-core
+```
+
+### Build Contract WASMs for Profiling
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```
+
+WASM files are written to `target/wasm32-unknown-unknown/release/`. Upload any `.wasm` file through the web dashboard or POST it directly to the simulation API.
+
+### Start the Web Dashboard
+
+```bash
+cd web
+npm install
+npm run dev
+# Open http://localhost:3000
+```
+
+---
+
+## Mainnet Deployment Steps
+
+> Complete the [Security Audit Checklist](./SECURITY_AUDIT_CHECKLIST.md) before proceeding.
+
+### 1. Build Release Artifacts
+
+```bash
+stellar contract build
+```
+
+This compiles all `cdylib` contracts to `target/wasm32-unknown-unknown/release/*.wasm`.
+
+### 2. Configure the Deployer Identity
+
+```bash
+# Import your Mainnet deployer key (stored in a secure vault)
+stellar keys add deployer --secret-key
+# Enter the secret key when prompted — do NOT pass it as a shell argument
+
+# Confirm the public key
+stellar keys address deployer
+```
+
+### 3. Deploy Each Contract
+
+```bash
+# Example: deploy the emergency_guard contract
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/emergency_guard.wasm \
+  --source deployer \
+  --network mainnet \
+  --fee 1000000
+```
+
+Record each returned contract ID. The automated CI deploy job (`deploy-testnet.yml`) writes a `deployment_manifest.txt` — replicate this process manually for Mainnet and store the manifest in version control.
+
+### 4. Initialize Contracts
+
+After deployment, call each contract's `initialize` entry point with the production admin multisig address and any required parameters:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source deployer \
+  --network mainnet \
+  -- initialize \
+  --admin <MULTISIG_ADDRESS> \
+  --fee_bps 30
+```
+
+### 5. Transfer Admin Authority
+
+Rotate the deployer key out of the admin role immediately after initialization:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source deployer \
+  --network mainnet \
+  -- transfer_admin \
+  --new_admin <PERMANENT_MULTISIG_ADDRESS>
+```
+
+### 6. Verify Deployment
+
+```bash
+# Read back the stored admin to confirm the rotation
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network mainnet \
+  -- get_admin
+```
+
+---
+
+## Network Configuration
+
+| Parameter | Testnet | Mainnet |
+|-----------|---------|---------|
+| RPC URL | `https://soroban-testnet.stellar.org` | `https://mainnet.sorobanrpc.com` |
+| Network passphrase | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
+| Stellar CLI flag | `--network testnet` | `--network mainnet` |
+
+To configure a named network profile locally:
+
+```bash
+stellar network add mainnet \
+  --rpc-url https://mainnet.sorobanrpc.com \
+  --network-passphrase "Public Global Stellar Network ; September 2015"
+```
+
+---
+
+## Troubleshooting
+
+**`error: failed to compile` on wasm32 target**
+Run `rustup target add wasm32-unknown-unknown` and retry.
+
+**`Insufficient funds` during deploy**
+The deployer account must be funded on Mainnet. Transfer XLM to the deployer public key before deploying.
+
+**`Transaction simulation failed`**
+Check that the `--fee` value is high enough for current network conditions. Use `stellar fee stats --network mainnet` to check current base fees.
+
+**Proof verification returns `false` after Merkle root update**
+See the Troubleshooting section in [`core/MERKLE_TREE_README.md`](../core/MERKLE_TREE_README.md).
+
+---
+
+## Related
+
+- [Security Audit Checklist](./SECURITY_AUDIT_CHECKLIST.md)
+- [Testnet Release Notes](../RELEASE_NOTES_TESTNET.md)
+- [Merkle Tree CLI Reference](../core/MERKLE_TREE_README.md)
+- [EmergencyGuard Setup](./EMERGENCY_GUARD_SETUP.md)
+</content>
+</invoke>

--- a/docs/SECURITY_AUDIT_CHECKLIST.md
+++ b/docs/SECURITY_AUDIT_CHECKLIST.md
@@ -1,0 +1,90 @@
+# Security Audit Checklist — Production Deployment
+
+This checklist must be reviewed and signed off before deploying any SoroScope contract to Stellar Mainnet.
+
+---
+
+## Admin Key Management
+
+- [ ] Admin secret keys are stored in a hardware security module (HSM) or equivalent secure vault — never in plaintext files or environment variables on shared systems.
+- [ ] The deployer secret key used during initial deployment is rotated immediately after deployment and the post-deployment admin key is set to the long-term multisig address.
+- [ ] No single person holds all signing keys for the multisig admin address.
+- [ ] Admin key rotation procedures are documented, tested on Testnet, and accessible to at least two team members.
+- [ ] CI/CD pipeline secrets (`TESTNET_DEPLOYER_SECRET_KEY` etc.) are scoped to their target environment and rotated on a defined schedule.
+
+---
+
+## Multisig Thresholds
+
+- [ ] All privileged operations (pause, unpause, admin rotation, emergency withdrawal) require M-of-N multisig approval where N ≥ 3 and M ≥ 2.
+- [ ] Multisig thresholds are validated on-chain — not just enforced by off-chain tooling.
+- [ ] The multisig configuration has been verified with the `scripts/audit_multisig_thresholds.py` script against the deployed contract state.
+- [ ] Threshold values are documented and match what was reviewed during audit.
+
+---
+
+## EmergencyGuard Configuration
+
+- [ ] Every deployed contract that handles user funds integrates `EmergencyGuard` (see [`contracts/emergency_guard/`](../contracts/emergency_guard/)).
+- [ ] Granular pause flags are configured for each sensitive operation (swap, deposit, withdrawal, transfer, mint, burn).
+- [ ] The initial pause state is verified to be unpaused (all bits = 0) before going live — unless a guarded rollout is intended.
+- [ ] An emergency pause runbook exists and is reachable by on-call engineers without needing repository access.
+- [ ] The `guard_unpause` path has been tested on Testnet under simulated incident conditions.
+
+---
+
+## Access Controls & Limits
+
+- [ ] All admin-only entry points are protected by an `require_auth` check against the stored admin address.
+- [ ] Fee parameters have hard-coded maximum caps that cannot be overridden by admin calls alone.
+- [ ] Any upgrade authority (if applicable) is locked to the multisig address.
+- [ ] There are no backdoor or debug entry points left active in the deployed WASM.
+
+---
+
+## Contract Deployment
+
+- [ ] WASM artifacts were compiled from a tagged release commit — not a development branch.
+- [ ] The deployed WASM hash has been verified against the locally-built artifact (`sha256sum`).
+- [ ] Contract IDs are recorded in a deployment manifest and stored in version control (see `deployment_manifest.txt` produced by the CI deploy job).
+- [ ] All constructor arguments (admin address, fee bps, limits) have been double-checked against the final deployment parameters doc.
+
+---
+
+## Cross-Chain Components
+
+- [ ] Merkle roots posted via `update_root` are only accepted from an authorized relayer address.
+- [ ] The relayer key is separate from the admin key and has no pause/admin authority.
+- [ ] `verify_message` proofs have been tested end-to-end on Testnet before enabling the Mainnet relayer.
+- [ ] A maximum batch size or rate limit is in place for root updates to prevent spam.
+
+---
+
+## Dependency & Build Review
+
+- [ ] `Cargo.lock` is committed and pinned — no wildcard version ranges for security-sensitive crates.
+- [ ] `cargo audit` has been run and all advisories reviewed (run `cargo install cargo-audit && cargo audit`).
+- [ ] The Soroban SDK version matches the version targeted in the audit report.
+- [ ] No `unsafe` blocks are present in contract code (verify with `grep -r "unsafe" contracts/`).
+
+---
+
+## Incident Response
+
+- [ ] An on-call rotation is in place before Mainnet launch.
+- [ ] The emergency pause key is accessible 24/7 to at least one on-call engineer.
+- [ ] A post-incident review process is defined and communicated to the team.
+- [ ] Contact information for the Stellar Foundation security team is documented for coordinated disclosure.
+
+---
+
+## Sign-off
+
+| Role | Name | Date |
+|------|------|------|
+| Lead Engineer | | |
+| Security Reviewer | | |
+| Multisig Key Holder 1 | | |
+| Multisig Key Holder 2 | | |
+</content>
+</invoke>


### PR DESCRIPTION
## Summary

- Adds Merkle Tree CLI usage section to the main README with key `soroban-cli` commands and a reference to the full API doc (#497)
- Adds an explicit `cargo check` job to the CI pipeline and replaces the stale README TODO with a description of the existing CI (#500)
- Creates `docs/SECURITY_AUDIT_CHECKLIST.md` — a production-deployment checklist covering admin keys, multisig thresholds, EmergencyGuard config, WASM verification, and incident response (#503)
- Creates `docs/MAINNET_DEPLOYMENT.md` — step-by-step guide for CLI installation, local simulation, and Stellar Mainnet contract deployment including key rotation and network config reference (#504)

## Closes

Closes #497
Closes #500
Closes #503
Closes #504

## Test plan

- [ ] CI pipeline runs `cargo check`, `cargo fmt`, `cargo clippy`, `cargo test`, and frontend lint on this branch
- [ ] `docs/SECURITY_AUDIT_CHECKLIST.md` renders correctly in GitHub and all section links resolve
- [ ] `docs/MAINNET_DEPLOYMENT.md` renders correctly and cross-links to related docs resolve
- [ ] Merkle Tree section in `README.md` is visible and CLI command blocks are formatted correctly