### PR TITLE
feat(infra,core): add testnet deployment script and double-hash leaf nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crucible-example-gasless"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/core/src/merkle_tree.rs
+++ b/core/src/merkle_tree.rs
@@ -198,8 +198,11 @@ impl MerkleTree {
     fn hash_leaf(data: &[u8]) -> [u8; 32] {
         let mut hasher = Sha256::new();
         hasher.update(data);
-        let digest = hasher.finalize();
-        digest.into()
+        let digest1 = hasher.finalize();
+        let mut hasher2 = Sha256::new();
+        hasher2.update(digest1);
+        let digest2 = hasher2.finalize();
+        digest2.into()
     }
 
     fn hash_pair(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {

--- a/scripts/deploy_testnet.sh
+++ b/scripts/deploy_testnet.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Automates building and deploying all workspace contracts to testnet.
+# Usage: scripts/deploy_testnet.sh --source-account <identity-or-secret>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SOURCE_ACCOUNT="${STELLAR_SOURCE_ACCOUNT:-}"
+NETWORK="${STELLAR_NETWORK:-testnet}"
+WASM_DIR="$REPO_ROOT/target/wasm32v1-none/release"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command '$1' not found"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-account|--source)
+      SOURCE_ACCOUNT="${2:-}"
+      shift 2
+      ;;
+    --network)
+      NETWORK="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 --source-account <identity-or-secret> [--network <name>]"
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -n "$SOURCE_ACCOUNT" ]] || die "--source-account is required"
+
+require_command stellar
+require_command cargo
+
+echo "Building all workspace contracts..."
+cargo build \
+  --manifest-path "$REPO_ROOT/Cargo.toml" \
+  --target wasm32v1-none \
+  --release
+
+echo "Deploying and initializing contracts to $NETWORK..."
+
+deployed=0
+for wasm in "$WASM_DIR"/*.wasm; do
+  [[ -f "$wasm" ]] || continue
+
+  contract_name=$(basename "$wasm" .wasm)
+  echo "Deploying $contract_name..."
+
+  CONTRACT_ID=$(stellar contract deploy \
+    --wasm "$wasm" \
+    --source-account "$SOURCE_ACCOUNT" \
+    --network "$NETWORK")
+
+  echo "Deployed $contract_name at $CONTRACT_ID"
+
+  if stellar contract invoke \
+      --id "$CONTRACT_ID" \
+      --source-account "$SOURCE_ACCOUNT" \
+      --network "$NETWORK" \
+      -- initialize >/dev/null 2>&1; then
+    echo "Initialized $contract_name successfully."
+  else
+    echo "$contract_name does not require initialization or requires arguments."
+  fi
+
+  deployed=$((deployed + 1))
+done
+
+echo "All deployments finished. Total contracts deployed: $deployed"


### PR DESCRIPTION
Closes #501
Closes #498

## PR Description

This PR addresses two separate issues that were assigned together.

**Issue #501 - Testnet automated deployment script**

Previously there was no general-purpose script to deploy all workspace contracts to testnet. The only deployment script in the repo was `scripts/deploy_cross_chain_verifier.sh`, which was specific to that single contract.

`scripts/deploy_testnet.sh` automates the full deployment flow: it builds every contract in the workspace to WASM using `cargo build --target wasm32v1-none --release`, then iterates over the output directory, deploys each `.wasm` file to testnet using the `stellar` CLI, and attempts a bare `initialize` call on each deployed contract. Contracts that do not expose a zero-argument `initialize` function are reported as skipped rather than failing the whole run.

The script accepts `--source-account` and `--network` as CLI arguments, reads `STELLAR_SOURCE_ACCOUNT` and `STELLAR_NETWORK` from the environment as fallbacks, validates required inputs before touching the network, and enforces the correct build target (`wasm32v1-none`) consistent with the rest of the repo.

**Issue #498 - Double-hashing leaf nodes for second-preimage protection**

The existing `hash_leaf` function in `core/src/merkle_tree.rs` applied a single round of SHA-256 to each leaf payload. This leaves the tree open to a structural second-preimage attack where an attacker can present an internal node hash as a valid leaf because both are produced by the same single-round hash function without domain separation.

`hash_leaf` now computes `SHA-256(SHA-256(data))`, first hashing the raw leaf bytes, then hashing the resulting 32-byte digest. Every code path that produces or verifies a leaf hash (`build`, `generate_proof`, `verify_proof`, `MerkleProof::verify`) calls the same `hash_leaf` function, so the change is consistent across the entire module with no additional changes needed.


## Changes Made

- **`scripts/deploy_testnet.sh`** (new file): shell script that builds all workspace contracts to `wasm32v1-none`, deploys each WASM to testnet via the `stellar CLI`, and attempts initialization. Accepts `--source-account` and `--network` flags. Validates `stellar` and `cargo` are present before running.
- **`core/src/merkle_tree.rs`**: updated `hash_leaf` to apply double SHA-256 (`SHA-256(SHA-256(data))`). No other logic in the module was modified.
- **`Cargo.lock`**: updated automatically as a result of the workspace build.


## Testing

```bash
# Verify merkle tree module compiles and tests pass in isolation
cargo test -p soroscope-core merkle_tree

# Validate script syntax (no network required)
bash -n scripts/deploy_testnet.sh
```

The merkle tree tests could not run to completion due to a pre-existing, unrelated compile error in `core/src/cache/mod.rs` (duplicate `impl` blocks for `SimulationCache`). That error is out of scope for this PR. Script syntax validation passed cleanly.


## Scope Notes

- `scripts/deploy_testnet.sh` is infrastructure-only. No contract logic was changed.
- `core/src/merkle_tree.rs` change is limited to the `hash_leaf` private function. No public API surface changed.
- No frontend changes.
- No dependency additions only `Cargo.lock` reflects the build output.