### PR TITLE
feat: invocation history sidebar + richer EmergencyGuard event payloads

### DIFF
--- a/contracts/emergency_guard/src/lib.rs
+++ b/contracts/emergency_guard/src/lib.rs
@@ -3,31 +3,20 @@
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, log, Address, Env, String, Vec,
 };
-#[cfg(feature = "contract")]
-use soroban_sdk::{contract, contractimpl};
-use soroban_sdk::{contracterror, contracttype, Address, Env, String, Vec};
 
-/// Granular pause types using bitmask for efficient storage
-/// Each bit represents a different pausable operation
+/// Granular pause types using bitmask for efficient storage.
+/// Each bit represents a different pausable operation.
 #[contracttype]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PauseType(u32);
 
 impl PauseType {
-    /// Pause swap operations
     pub const SWAP: u32 = 1 << 0;
-    /// Pause deposit operations
     pub const DEPOSIT: u32 = 1 << 1;
-    /// Pause withdraw operations
     pub const WITHDRAW: u32 = 1 << 2;
-    /// Pause all token transfers
     pub const TRANSFER: u32 = 1 << 3;
-    /// Pause minting
     pub const MINT: u32 = 1 << 4;
-    /// Pause burning
     pub const BURN: u32 = 1 << 5;
-    /// Pause liquidity-pool pair creation in factory contracts
-    /// Pause factory pair creation
     pub const CREATE_PAIR: u32 = 1 << 6;
 
     pub fn new(value: u32) -> Self {
@@ -59,7 +48,7 @@ impl PauseType {
     }
 }
 
-/// Data keys for emergency guard storage (named uniquely to avoid WASM metadata collisions)
+/// Data keys for emergency guard storage.
 #[contracttype]
 pub enum GuardDataKey {
     /// Pause state bitmask: PauseType(u32)
@@ -70,7 +59,7 @@ pub enum GuardDataKey {
     SignatureThreshold,
 }
 
-/// Error codes
+/// Error codes.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(u32)]
@@ -98,6 +87,11 @@ pub enum EmergencyGuardAction {
 }
 
 /// Standardized event payload for EmergencyGuard administrative actions.
+///
+/// Fields:
+/// - `admin_count`: total number of registered admins at the time of the event
+/// - `approver_count`: number of addresses submitted in the approvers list
+/// - `signatures_count`: number of valid unique admin signatures verified
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EmergencyGuardEvent {
@@ -108,7 +102,81 @@ pub struct EmergencyGuardEvent {
     pub threshold: u32,
     pub admin_count: u32,
     pub approver_count: u32,
+    pub signatures_count: u32,
 }
+
+// ---------------------------------------------------------------------------
+// Legacy per-action event structs — also enriched with admin_count and
+// signatures_count so every emitted event carries the full context.
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GuardInitializedEvent {
+    pub admins: Vec<Address>,
+    pub threshold: u32,
+    pub admin_count: u32,
+    pub signatures_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PauseStateChangedEvent {
+    pub admin: Address,
+    pub operation: u32,
+    pub paused: bool,
+    pub admin_count: u32,
+    pub signatures_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmergencyPausedEvent {
+    pub approvers: Vec<Address>,
+    pub admin_count: u32,
+    pub signatures_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResumedEvent {
+    pub approvers: Vec<Address>,
+    pub admin_count: u32,
+    pub signatures_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminAddedEvent {
+    pub approvers: Vec<Address>,
+    pub new_admin: Address,
+    pub admin_count: u32,
+    pub signatures_count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminRemovedEvent {
+    pub approvers: Vec<Address>,
+    pub admin: Address,
+    pub admin_count: u32,
+    pub signatures_count: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Event constants
+// ---------------------------------------------------------------------------
+
+const EVENT_INIT_GUARD: &str = "emergency_guard_initialized";
+const EVENT_SET_PAUSE: &str = "emergency_guard_pause_state_changed";
+const EVENT_EMERGENCY_PAUSE_ALL: &str = "emergency_guard_emergency_paused_all";
+const EVENT_RESUME_ALL: &str = "emergency_guard_resumed_all";
+const EVENT_ADD_ADMIN: &str = "emergency_guard_admin_added";
+const EVENT_REMOVE_ADMIN: &str = "emergency_guard_admin_removed";
+
+// ---------------------------------------------------------------------------
+// Emit helpers — unified EmergencyGuardEvent
+// ---------------------------------------------------------------------------
 
 fn action_topic(env: &Env, action: EmergencyGuardAction) -> String {
     match action {
@@ -130,186 +198,168 @@ fn emit_guard_event(env: &Env, event: EmergencyGuardEvent) {
         ),
         event,
     );
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GuardInitializedEvent {
-    pub admins: Vec<Address>,
-    pub threshold: u32,
 }
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PauseStateChangedEvent {
-    pub admin: Address,
-    pub operation: u32,
-    pub paused: bool,
-}
+// ---------------------------------------------------------------------------
+// Emit helpers — legacy per-action events
+// ---------------------------------------------------------------------------
 
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct EmergencyPausedEvent {
-    pub approvers: Vec<Address>,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ResumedEvent {
-    pub approvers: Vec<Address>,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AdminAddedEvent {
-    pub approvers: Vec<Address>,
-    pub new_admin: Address,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AdminRemovedEvent {
-    pub approvers: Vec<Address>,
-    pub admin: Address,
-}
-/// Result type for guard operations
-// Result type for guard operations replaced inline
-
-/// EmergencyGuard trait for standardized pause and admin management
-pub trait EmergencyGuardTrait {
-    /// Check if an operation is paused. Returns Err if paused.
-    fn check_not_paused(env: &Env, operation: u32) -> Result<(), GuardError>;
-
-    /// Get current pause state
-    fn get_pause_state(env: &Env) -> u32;
-
-    /// Set pause state for a specific operation (any single admin can do this)
-    fn set_pause_state(env: &Env, operation: u32, paused: bool) -> Result<(), GuardError>;
-
-    /// Unpause a specific operation (any single admin can do this)
-    fn unpause(env: &Env, operation: u32) -> Result<(), GuardError>;
-
-    /// Unpause all operations (any single admin can do this)
-    fn unpause_all(env: &Env) -> Result<(), GuardError>;
-
-    /// Emergency pause all operations (requires multi-sig approval)
-    fn emergency_pause_all(env: &Env, approvers: Vec<Address>) -> Result<(), GuardError>;
-
-    /// Resume all operations (requires multi-sig approval)
-    fn resume_all(env: &Env, approvers: Vec<Address>) -> Result<(), GuardError>;
-
-    /// Initialize emergency guard with admins and threshold
-    fn init_guard(env: &Env, admins: Vec<Address>, threshold: u32) -> Result<(), GuardError>;
-
-    /// Add new admin (multi-sig required)
-    fn add_admin(env: &Env, approvers: Vec<Address>, new_admin: Address) -> Result<(), GuardError>;
-
-    /// Remove admin (multi-sig required)
-    fn remove_admin(env: &Env, approvers: Vec<Address>, admin: Address) -> Result<(), GuardError>;
-
-    /// Rotate admin (multi-sig required)
-    fn rotate_admin(env: &Env, approvers: Vec<Address>, old_admin: Address, new_admin: Address) -> Result<(), GuardError>;
-
-    /// Get list of current admins
-    fn get_admins(env: &Env) -> Vec<Address>;
-
-    /// Get required signature threshold
-    fn get_threshold(env: &Env) -> u32;
-
-    /// Check if address is an admin
-    fn is_admin(env: &Env, addr: &Address) -> bool;
-}
-
-const EVENT_INIT_GUARD: &str = "emergency_guard_initialized";
-const EVENT_SET_PAUSE: &str = "emergency_guard_pause_state_changed";
-const EVENT_EMERGENCY_PAUSE_ALL: &str = "emergency_guard_emergency_paused_all";
-const EVENT_RESUME_ALL: &str = "emergency_guard_resumed_all";
-const EVENT_ADD_ADMIN: &str = "emergency_guard_admin_added";
-const EVENT_REMOVE_ADMIN: &str = "emergency_guard_admin_removed";
-
-pub fn emit_guard_initialized(e: &Env, admins: &Vec<Address>, threshold: u32) {
+pub fn emit_guard_initialized(
+    e: &Env,
+    admins: &Vec<Address>,
+    threshold: u32,
+    signatures_count: u32,
+) {
     e.events().publish(
         (String::from_str(e, EVENT_INIT_GUARD),),
         GuardInitializedEvent {
             admins: admins.clone(),
             threshold,
+            admin_count: admins.len(),
+            signatures_count,
         },
     );
 }
 
-pub fn emit_pause_state_changed(e: &Env, admin: &Address, operation: u32, paused: bool) {
+pub fn emit_pause_state_changed(
+    e: &Env,
+    admin: &Address,
+    operation: u32,
+    paused: bool,
+    admin_count: u32,
+    signatures_count: u32,
+) {
     e.events().publish(
         (String::from_str(e, EVENT_SET_PAUSE), admin.clone()),
         PauseStateChangedEvent {
             admin: admin.clone(),
             operation,
             paused,
+            admin_count,
+            signatures_count,
         },
     );
 }
 
-pub fn emit_emergency_paused_all(e: &Env, approvers: &Vec<Address>) {
+pub fn emit_emergency_paused_all(
+    e: &Env,
+    approvers: &Vec<Address>,
+    admin_count: u32,
+    signatures_count: u32,
+) {
     e.events().publish(
         (String::from_str(e, EVENT_EMERGENCY_PAUSE_ALL),),
         EmergencyPausedEvent {
             approvers: approvers.clone(),
+            admin_count,
+            signatures_count,
         },
     );
 }
 
-pub fn emit_resumed_all(e: &Env, approvers: &Vec<Address>) {
+pub fn emit_resumed_all(
+    e: &Env,
+    approvers: &Vec<Address>,
+    admin_count: u32,
+    signatures_count: u32,
+) {
     e.events().publish(
         (String::from_str(e, EVENT_RESUME_ALL),),
         ResumedEvent {
             approvers: approvers.clone(),
+            admin_count,
+            signatures_count,
         },
     );
 }
 
-pub fn emit_admin_added(e: &Env, approvers: &Vec<Address>, new_admin: &Address) {
+pub fn emit_admin_added(
+    e: &Env,
+    approvers: &Vec<Address>,
+    new_admin: &Address,
+    admin_count: u32,
+    signatures_count: u32,
+) {
     e.events().publish(
         (String::from_str(e, EVENT_ADD_ADMIN), new_admin.clone()),
         AdminAddedEvent {
             approvers: approvers.clone(),
             new_admin: new_admin.clone(),
+            admin_count,
+            signatures_count,
         },
     );
 }
 
-pub fn emit_admin_removed(e: &Env, approvers: &Vec<Address>, admin: &Address) {
+pub fn emit_admin_removed(
+    e: &Env,
+    approvers: &Vec<Address>,
+    admin: &Address,
+    admin_count: u32,
+    signatures_count: u32,
+) {
     e.events().publish(
         (String::from_str(e, EVENT_REMOVE_ADMIN), admin.clone()),
         AdminRemovedEvent {
             approvers: approvers.clone(),
             admin: admin.clone(),
+            admin_count,
+            signatures_count,
         },
     );
 }
 
+// ---------------------------------------------------------------------------
+// EmergencyGuardTrait
+// ---------------------------------------------------------------------------
+
+pub trait EmergencyGuardTrait {
+    fn check_not_paused(env: &Env, operation: u32) -> Result<(), GuardError>;
+    fn get_pause_state(env: &Env) -> u32;
+    fn set_pause_state(env: &Env, operation: u32, paused: bool) -> Result<(), GuardError>;
+    fn unpause(env: &Env, operation: u32) -> Result<(), GuardError>;
+    fn unpause_all(env: &Env) -> Result<(), GuardError>;
+    fn emergency_pause_all(env: &Env, approvers: Vec<Address>) -> Result<(), GuardError>;
+    fn resume_all(env: &Env, approvers: Vec<Address>) -> Result<(), GuardError>;
+    fn init_guard(env: &Env, admins: Vec<Address>, threshold: u32) -> Result<(), GuardError>;
+    fn add_admin(env: &Env, approvers: Vec<Address>, new_admin: Address) -> Result<(), GuardError>;
+    fn remove_admin(env: &Env, approvers: Vec<Address>, admin: Address) -> Result<(), GuardError>;
+    fn rotate_admin(
+        env: &Env,
+        approvers: Vec<Address>,
+        old_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), GuardError>;
+    fn get_admins(env: &Env) -> Vec<Address>;
+    fn get_threshold(env: &Env) -> u32;
+    fn is_admin(env: &Env, addr: &Address) -> bool;
+}
+
+// ---------------------------------------------------------------------------
+// Main contract
+// ---------------------------------------------------------------------------
+
 #[contract]
-#[cfg_attr(feature = "contract", contract)]
 pub struct EmergencyGuard;
 
-#[cfg_attr(feature = "contract", contractimpl)]
+#[contractimpl]
 impl EmergencyGuard {
-    /// Initialize the emergency guard with a list of admins and required threshold
+    /// Initialize the emergency guard with a list of admins and required threshold.
     pub fn initialize(env: Env, admins: Vec<Address>, threshold: u32) -> Result<(), GuardError> {
         if env.storage().instance().has(&GuardDataKey::Admins) {
             return Err(GuardError::AlreadyInitialized);
         }
 
-        // Verify threshold is valid
         if threshold == 0 || threshold > admins.len() {
             return Err(GuardError::InvalidThreshold);
         }
 
-        // Store admins
-        env.storage().instance().set(&GuardDataKey::Admins, &admins);
+        let admin_count = admins.len();
 
-        // Store threshold
+        env.storage().instance().set(&GuardDataKey::Admins, &admins);
         env.storage()
             .instance()
             .set(&GuardDataKey::SignatureThreshold, &threshold);
-
-        // Initialize pause state to 0 (nothing paused)
         env.storage()
             .instance()
             .set(&GuardDataKey::PauseState, &PauseType::new(0));
@@ -322,11 +372,12 @@ impl EmergencyGuard {
                 operation: 0,
                 paused: false,
                 threshold,
-                admin_count: admins.len(),
+                admin_count,
                 approver_count: 0,
+                signatures_count: 0,
             },
         );
-        emit_guard_initialized(&env, &admins, threshold);
+        emit_guard_initialized(&env, &admins, threshold, 0);
 
         Ok(())
     }
@@ -336,23 +387,22 @@ impl EmergencyGuard {
         let pause_state: PauseType = env
             .storage()
             .instance()
-            .get(&DataKey::PauseState)
+            .get(&GuardDataKey::PauseState)
             .unwrap_or(PauseType::new(0));
         pause_state.as_u32()
     }
 
-    /// Check if an operation is paused
+    /// Check if an operation is paused.
     pub fn is_paused(env: Env, operation: u32) -> bool {
         let pause_state: PauseType = env
             .storage()
             .instance()
             .get(&GuardDataKey::PauseState)
             .unwrap_or(PauseType::new(0));
-
         pause_state.is_paused(operation)
     }
 
-    /// Set pause state for a specific operation (any single admin can do this)
+    /// Set pause state for a specific operation (any single admin can do this).
     pub fn set_pause(
         env: Env,
         admin: Address,
@@ -361,7 +411,6 @@ impl EmergencyGuard {
     ) -> Result<(), GuardError> {
         admin.require_auth();
 
-        // Check if caller is admin
         if !Self::is_admin_internal(&env, &admin) {
             return Err(GuardError::Unauthorized);
         }
@@ -377,45 +426,40 @@ impl EmergencyGuard {
             .instance()
             .set(&GuardDataKey::PauseState, &pause_state);
 
+        let admin_count = Self::get_admins(env.clone()).len();
+        let threshold = Self::get_threshold(env.clone());
+
         emit_guard_event(
             &env,
             EmergencyGuardEvent {
                 action: EmergencyGuardAction::PauseSet,
-                admin: Some(admin),
+                admin: Some(admin.clone()),
                 operation,
                 paused,
-                threshold: Self::get_threshold(env.clone()),
-                admin_count: Self::get_admins(env.clone()).len(),
+                threshold,
+                admin_count,
                 approver_count: 1,
+                signatures_count: 1,
             },
         );
-        log!(
-            &env,
-            "Pause state updated: op={}, paused={}",
-            operation,
-            paused
-        emit_pause_state_changed(&env, &admin, operation, paused);
-        // Emit standardized EmergencyGuard event
-        env.events().publish(
-            (
-                String::from_str(&env, "emergency_guard.set_pause"),
-                admin.clone(),
-            ),
-            (operation, paused),
-        );
+        emit_pause_state_changed(&env, &admin, operation, paused, admin_count, 1);
+
+        log!(&env, "Pause state updated: op={}, paused={}", operation, paused);
         Ok(())
     }
 
-    /// Emergency pause all operations (requires multi-sig approval)
+    /// Emergency pause all operations (requires multi-sig approval).
     pub fn emergency_pause(env: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
-        Self::check_multi_sig(&env, &approvers)?;
+        let signatures_count = Self::check_multi_sig(&env, &approvers)?;
 
         let mut pause_state = PauseType::new(0);
         pause_state.pause_all();
-
         env.storage()
             .instance()
             .set(&GuardDataKey::PauseState, &pause_state);
+
+        let admin_count = Self::get_admins(env.clone()).len();
+        let threshold = Self::get_threshold(env.clone());
 
         emit_guard_event(
             &env,
@@ -424,30 +468,29 @@ impl EmergencyGuard {
                 admin: None,
                 operation: u32::MAX,
                 paused: true,
-                threshold: Self::get_threshold(env.clone()),
-                admin_count: Self::get_admins(env.clone()).len(),
+                threshold,
+                admin_count,
                 approver_count: approvers.len(),
+                signatures_count,
             },
-        emit_emergency_paused_all(&env, &approvers);
-        env.events().publish(
-            (String::from_str(
-                &env,
-                "emergency_guard.emergency_pause_all",
-            ),),
-            (approvers.clone(),),
         );
+        emit_emergency_paused_all(&env, &approvers, admin_count, signatures_count);
+
         log!(&env, "Emergency pause all activated");
         Ok(())
     }
 
-    /// Resume all operations (requires multi-sig approval)
+    /// Resume all operations (requires multi-sig approval).
     pub fn resume(env: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
-        Self::check_multi_sig(&env, &approvers)?;
+        let signatures_count = Self::check_multi_sig(&env, &approvers)?;
 
         let pause_state = PauseType::new(0);
         env.storage()
             .instance()
             .set(&GuardDataKey::PauseState, &pause_state);
+
+        let admin_count = Self::get_admins(env.clone()).len();
+        let threshold = Self::get_threshold(env.clone());
 
         emit_guard_event(
             &env,
@@ -456,31 +499,34 @@ impl EmergencyGuard {
                 admin: None,
                 operation: u32::MAX,
                 paused: false,
-                threshold: Self::get_threshold(env.clone()),
-                admin_count: Self::get_admins(env.clone()).len(),
+                threshold,
+                admin_count,
                 approver_count: approvers.len(),
+                signatures_count,
             },
-        emit_resumed_all(&env, &approvers);
-        env.events().publish(
-            (String::from_str(&env, "emergency_guard.resume_all"),),
-            (approvers.clone(),),
         );
+        emit_resumed_all(&env, &approvers, admin_count, signatures_count);
+
         log!(&env, "Resume all activated");
         Ok(())
     }
 
-    /// Add new admin (multi-sig required)
+    /// Add new admin (multi-sig required).
     pub fn add_admin(
         env: Env,
         approvers: Vec<Address>,
         new_admin: Address,
     ) -> Result<(), GuardError> {
-        Self::check_multi_sig(&env, &approvers)?;
+        let signatures_count = Self::check_multi_sig(&env, &approvers)?;
 
         let mut admins = Self::get_admins(env.clone());
         if !admins.iter().any(|a| a == new_admin) {
             admins.push_back(new_admin.clone());
-            env.storage().instance().set(&DataKey::Admins, &admins);
+            env.storage().instance().set(&GuardDataKey::Admins, &admins);
+
+            let admin_count = admins.len();
+            let threshold = Self::get_threshold(env.clone());
+
             emit_guard_event(
                 &env,
                 EmergencyGuardEvent {
@@ -488,32 +534,27 @@ impl EmergencyGuard {
                     admin: Some(new_admin.clone()),
                     operation: 0,
                     paused: false,
-                    threshold: Self::get_threshold(env.clone()),
-                    admin_count: admins.len(),
+                    threshold,
+                    admin_count,
                     approver_count: approvers.len(),
+                    signatures_count,
                 },
-            emit_admin_added(&env, &approvers, &new_admin);
-            env.storage().instance().set(&GuardDataKey::Admins, &admins);
-            env.events().publish(
-                (
-                    String::from_str(&env, "emergency_guard.admin_added"),
-                    new_admin.clone(),
-                ),
-                (),
             );
+            emit_admin_added(&env, &approvers, &new_admin, admin_count, signatures_count);
+
             log!(&env, "Admin added: {}", new_admin);
         }
 
         Ok(())
     }
 
-    /// Remove admin (multi-sig required)
+    /// Remove admin (multi-sig required).
     pub fn remove_admin(
         env: Env,
         approvers: Vec<Address>,
         admin: Address,
     ) -> Result<(), GuardError> {
-        Self::check_multi_sig(&env, &approvers)?;
+        let signatures_count = Self::check_multi_sig(&env, &approvers)?;
 
         let admins = Self::get_admins(env.clone());
         let threshold = Self::get_threshold(env.clone());
@@ -536,7 +577,12 @@ impl EmergencyGuard {
             return Err(GuardError::AdminNotFound);
         }
 
-        env.storage().instance().set(&DataKey::Admins, &new_admins);
+        env.storage()
+            .instance()
+            .set(&GuardDataKey::Admins, &new_admins);
+
+        let admin_count = new_admins.len();
+
         emit_guard_event(
             &env,
             EmergencyGuardEvent {
@@ -545,36 +591,31 @@ impl EmergencyGuard {
                 operation: 0,
                 paused: false,
                 threshold,
-                admin_count: new_admins.len(),
+                admin_count,
                 approver_count: approvers.len(),
+                signatures_count,
             },
-        emit_admin_removed(&env, &approvers, &admin);
-        env.storage().instance().set(&GuardDataKey::Admins, &new_admins);
-        env.events().publish(
-            (
-                String::from_str(&env, "emergency_guard.admin_removed"),
-                admin.clone(),
-            ),
-            (),
         );
+        emit_admin_removed(&env, &approvers, &admin, admin_count, signatures_count);
+
         log!(&env, "Admin removed: {}", admin);
         Ok(())
     }
 
-    /// Rotate admin (multi-sig required)
+    /// Rotate admin (multi-sig required).
     pub fn rotate_admin(
         env: Env,
         approvers: Vec<Address>,
         old_admin: Address,
         new_admin: Address,
     ) -> Result<(), GuardError> {
-        Self::check_multi_sig(&env, &approvers)?;
+        let signatures_count = Self::check_multi_sig(&env, &approvers)?;
 
-        let mut admins = Self::get_admins(env.clone());
+        let admins = Self::get_admins(env.clone());
         let threshold = Self::get_threshold(env.clone());
 
+        let mut new_admins = Vec::new(&env);
         let mut found = false;
-        let mut new_admins = soroban_sdk::Vec::new(&env);
         for a in admins.iter() {
             if a == old_admin {
                 found = true;
@@ -589,11 +630,16 @@ impl EmergencyGuard {
 
         new_admins.push_back(new_admin.clone());
 
-        if (new_admins.len() as u32) < threshold {
+        if new_admins.len() < threshold {
             return Err(GuardError::InvalidThreshold);
         }
 
-        env.storage().instance().set(&DataKey::Admins, &new_admins);
+        env.storage()
+            .instance()
+            .set(&GuardDataKey::Admins, &new_admins);
+
+        let admin_count = new_admins.len();
+
         emit_guard_event(
             &env,
             EmergencyGuardEvent {
@@ -602,15 +648,17 @@ impl EmergencyGuard {
                 operation: 0,
                 paused: false,
                 threshold,
-                admin_count: new_admins.len(),
+                admin_count,
                 approver_count: approvers.len(),
+                signatures_count,
             },
         );
+
         log!(&env, "Admin rotated: {} to {}", old_admin, new_admin);
         Ok(())
     }
 
-    /// Get list of current admins
+    /// Get list of current admins.
     pub fn get_admins(env: Env) -> Vec<Address> {
         env.storage()
             .instance()
@@ -618,7 +666,7 @@ impl EmergencyGuard {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
-    /// Get required signature threshold
+    /// Get required signature threshold.
     pub fn get_threshold(env: Env) -> u32 {
         env.storage()
             .instance()
@@ -626,12 +674,19 @@ impl EmergencyGuard {
             .unwrap_or(0)
     }
 
-    /// Authorize administration operations by verifying the caller approvers against the guard threshold.
-    pub fn authorize(env: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
-        Self::check_multi_sig(&env, &approvers)
+    /// Public method to check if an address is an admin.
+    pub fn is_admin_public(env: Env, addr: Address) -> bool {
+        Self::is_admin_internal(&env, &addr)
     }
 
+    /// Validate a set of approvers against the stored threshold.
+    pub fn authorize(env: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
+        Self::check_multi_sig(&env, &approvers).map(|_| ())
+    }
+
+    // -----------------------------------------------------------------------
     // Internal helpers
+    // -----------------------------------------------------------------------
 
     fn is_admin_internal(env: &Env, addr: &Address) -> bool {
         let admins: Vec<Address> = env
@@ -639,12 +694,12 @@ impl EmergencyGuard {
             .instance()
             .get(&GuardDataKey::Admins)
             .unwrap_or_else(|| Vec::new(env));
-
         admins.iter().any(|a| a == *addr)
     }
 
-    fn check_multi_sig(env: &Env, approvers: &Vec<Address>) -> Result<(), GuardError> {
-        let threshold = env
+    /// Verify multi-sig quorum and return the count of valid unique signatures.
+    fn check_multi_sig(env: &Env, approvers: &Vec<Address>) -> Result<u32, GuardError> {
+        let threshold: u32 = env
             .storage()
             .instance()
             .get(&GuardDataKey::SignatureThreshold)
@@ -654,48 +709,42 @@ impl EmergencyGuard {
             return Err(GuardError::InsufficientSignatures);
         }
 
-        let mut valid_approvers = 0;
+        let mut valid_signatures: u32 = 0;
         let mut seen = Vec::new(env);
 
         for addr in approvers.iter() {
-            // Avoid duplicates
             if seen.iter().any(|a| a == addr) {
                 continue;
             }
             seen.push_back(addr.clone());
 
-            // Check if address is an admin
             if Self::is_admin_internal(env, &addr) {
                 addr.require_auth();
-                valid_approvers += 1;
+                valid_signatures += 1;
             }
         }
 
-        if valid_approvers < threshold {
+        if valid_signatures < threshold {
             Err(GuardError::InsufficientSignatures)
         } else {
-            Ok(())
+            Ok(valid_signatures)
         }
-    }
-
-    /// Public method to check if an address is an admin
-    pub fn is_admin_public(env: Env, addr: Address) -> bool {
-        Self::is_admin_internal(&env, &addr)
     }
 }
 
-/// Default implementation of EmergencyGuardTrait using static methods
+// ---------------------------------------------------------------------------
+// DefaultEmergencyGuard — trait implementation for embedding in other contracts
+// ---------------------------------------------------------------------------
+
 pub struct DefaultEmergencyGuard;
 
 impl EmergencyGuardTrait for DefaultEmergencyGuard {
-    /// Check if an operation is paused. Returns Err if paused.
     fn check_not_paused(env: &Env, operation: u32) -> Result<(), GuardError> {
         let pause_state: PauseType = env
             .storage()
             .instance()
-            .get(&DataKey::PauseState)
+            .get(&GuardDataKey::PauseState)
             .unwrap_or(PauseType::new(0));
-
         if pause_state.is_paused(operation) {
             Err(GuardError::Paused)
         } else {
@@ -703,134 +752,98 @@ impl EmergencyGuardTrait for DefaultEmergencyGuard {
         }
     }
 
-    /// Get current pause state
     fn get_pause_state(env: &Env) -> u32 {
         let pause_state: PauseType = env
             .storage()
             .instance()
-            .get(&DataKey::PauseState)
+            .get(&GuardDataKey::PauseState)
             .unwrap_or(PauseType::new(0));
         pause_state.0
     }
 
-    /// Set pause state for a specific operation (any single admin can do this)
     fn set_pause_state(env: &Env, operation: u32, paused: bool) -> Result<(), GuardError> {
         let mut pause_state: PauseType = env
             .storage()
             .instance()
-            .get(&DataKey::PauseState)
+            .get(&GuardDataKey::PauseState)
             .unwrap_or(PauseType::new(0));
-
         pause_state.set_paused(operation, paused);
         env.storage()
             .instance()
-            .set(&DataKey::PauseState, &pause_state);
-
-        log!(
-            env,
-            "Pause state updated: op={}, paused={}",
-            operation,
-            paused
-        );
+            .set(&GuardDataKey::PauseState, &pause_state);
+        log!(env, "Pause state updated: op={}, paused={}", operation, paused);
         Ok(())
     }
 
-    /// Unpause a specific operation (any single admin can do this)
     fn unpause(env: &Env, operation: u32) -> Result<(), GuardError> {
         Self::set_pause_state(env, operation, false)
     }
 
-    /// Unpause all operations (any single admin can do this)
     fn unpause_all(env: &Env) -> Result<(), GuardError> {
         let pause_state = PauseType::new(0);
         env.storage()
             .instance()
-            .set(&DataKey::PauseState, &pause_state);
-
+            .set(&GuardDataKey::PauseState, &pause_state);
         log!(env, "All operations unpaused");
         Ok(())
     }
 
-    /// Emergency pause all operations (requires multi-sig approval)
     fn emergency_pause_all(env: &Env, approvers: Vec<Address>) -> Result<(), GuardError> {
         EmergencyGuard::check_multi_sig(env, &approvers)?;
-
         let mut pause_state = PauseType::new(0);
         pause_state.pause_all();
-
         env.storage()
             .instance()
-            .set(&DataKey::PauseState, &pause_state);
-
+            .set(&GuardDataKey::PauseState, &pause_state);
         log!(env, "Emergency pause all activated");
         Ok(())
     }
 
-    /// Resume all operations (unpause all) - requires multi-sig approval
     fn resume_all(env: &Env, approvers: Vec<Address>) -> Result<(), GuardError> {
         EmergencyGuard::check_multi_sig(env, &approvers)?;
-
         let pause_state = PauseType::new(0);
         env.storage()
             .instance()
-            .set(&DataKey::PauseState, &pause_state);
-
+            .set(&GuardDataKey::PauseState, &pause_state);
         log!(env, "All operations resumed (unpaused)");
         Ok(())
     }
 
-    /// Initialize emergency guard with admins and threshold
     fn init_guard(env: &Env, admins: Vec<Address>, threshold: u32) -> Result<(), GuardError> {
-        if env.storage().instance().has(&DataKey::Admins) {
+        if env.storage().instance().has(&GuardDataKey::Admins) {
             return Err(GuardError::AlreadyInitialized);
         }
-
-        // Verify threshold is valid
-        if threshold == 0 || threshold > admins.len() as u32 {
+        if threshold == 0 || threshold > admins.len() {
             return Err(GuardError::InvalidThreshold);
         }
-
-        // Store admins
-        env.storage().instance().set(&DataKey::Admins, &admins);
-
-        // Store threshold
+        env.storage().instance().set(&GuardDataKey::Admins, &admins);
         env.storage()
             .instance()
-            .set(&DataKey::SignatureThreshold, &threshold);
-
-        // Initialize pause state to 0 (nothing paused)
+            .set(&GuardDataKey::SignatureThreshold, &threshold);
         env.storage()
             .instance()
-            .set(&DataKey::PauseState, &PauseType::new(0));
-
+            .set(&GuardDataKey::PauseState, &PauseType::new(0));
         Ok(())
     }
 
-    /// Add new admin (multi-sig required)
     fn add_admin(env: &Env, approvers: Vec<Address>, new_admin: Address) -> Result<(), GuardError> {
         EmergencyGuard::check_multi_sig(env, &approvers)?;
-
         let mut admins = Self::get_admins(env);
         if !admins.iter().any(|a| a == new_admin) {
             admins.push_back(new_admin.clone());
-            env.storage().instance().set(&DataKey::Admins, &admins);
+            env.storage().instance().set(&GuardDataKey::Admins, &admins);
             log!(env, "Admin added: {}", new_admin);
         }
-
         Ok(())
     }
 
-    /// Remove admin (multi-sig required)
     fn remove_admin(env: &Env, approvers: Vec<Address>, admin: Address) -> Result<(), GuardError> {
         EmergencyGuard::check_multi_sig(env, &approvers)?;
-
         let admins = Self::get_admins(env);
         let threshold = Self::get_threshold(env);
-
-        if admins.len() as u32 <= threshold {
+        if admins.len() <= threshold {
             return Err(GuardError::InvalidThreshold);
         }
-
         let mut new_admins = Vec::new(env);
         let mut found = false;
         for a in admins.iter() {
@@ -840,78 +853,100 @@ impl EmergencyGuardTrait for DefaultEmergencyGuard {
                 found = true;
             }
         }
-
         if !found {
             return Err(GuardError::AdminNotFound);
         }
-
-        env.storage().instance().set(&DataKey::Admins, &new_admins);
+        env.storage()
+            .instance()
+            .set(&GuardDataKey::Admins, &new_admins);
         log!(env, "Admin removed: {}", admin);
         Ok(())
     }
 
-    /// Get list of current admins
+    fn rotate_admin(
+        env: &Env,
+        approvers: Vec<Address>,
+        old_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), GuardError> {
+        EmergencyGuard::check_multi_sig(env, &approvers)?;
+        let admins = Self::get_admins(env);
+        let threshold = Self::get_threshold(env);
+        let mut new_admins = Vec::new(env);
+        let mut found = false;
+        for a in admins.iter() {
+            if a == old_admin {
+                found = true;
+            } else if a != new_admin {
+                new_admins.push_back(a);
+            }
+        }
+        if !found {
+            return Err(GuardError::AdminNotFound);
+        }
+        new_admins.push_back(new_admin.clone());
+        if new_admins.len() < threshold {
+            return Err(GuardError::InvalidThreshold);
+        }
+        env.storage()
+            .instance()
+            .set(&GuardDataKey::Admins, &new_admins);
+        log!(env, "Admin rotated: {} to {}", old_admin, new_admin);
+        Ok(())
+    }
+
     fn get_admins(env: &Env) -> Vec<Address> {
         env.storage()
             .instance()
-            .get(&DataKey::Admins)
+            .get(&GuardDataKey::Admins)
             .unwrap_or_else(|| Vec::new(env))
     }
 
-    /// Get required signature threshold
     fn get_threshold(env: &Env) -> u32 {
         env.storage()
             .instance()
-            .get(&DataKey::SignatureThreshold)
+            .get(&GuardDataKey::SignatureThreshold)
             .unwrap_or(0)
     }
 
-    /// Check if address is an admin
     fn is_admin(env: &Env, addr: &Address) -> bool {
         let admins: Vec<Address> = env
             .storage()
             .instance()
-            .get(&DataKey::Admins)
+            .get(&GuardDataKey::Admins)
             .unwrap_or_else(|| Vec::new(env));
-
         admins.iter().any(|a| a == *addr)
     }
 }
 
-/// Extension methods for unpause operations
 impl DefaultEmergencyGuard {
-    /// Unpause a specific operation (uses set_pause_state internally)
-    pub fn unpause(env: &Env, operation: u32) -> Result<(), GuardError> {
+    pub fn unpause_operation(env: &Env, operation: u32) -> Result<(), GuardError> {
         Self::set_pause_state(env, operation, false)
     }
 
-    /// Unpause all operations (single-admin helper; same effect as `unpause_all`)
     pub fn unpause_all_emergency(env: &Env) -> Result<(), GuardError> {
         let pause_state = PauseType::new(0);
         env.storage()
             .instance()
-            .set(&DataKey::PauseState, &pause_state);
-
+            .set(&GuardDataKey::PauseState, &pause_state);
         log!(env, "All operations unpaused");
         Ok(())
     }
 
-    /// Check if a specific operation is paused
     pub fn is_operation_paused(env: &Env, operation: u32) -> bool {
         let pause_state: PauseType = env
             .storage()
             .instance()
-            .get(&DataKey::PauseState)
+            .get(&GuardDataKey::PauseState)
             .unwrap_or(PauseType::new(0));
-
         pause_state.is_paused(operation)
     }
 
-    /// Pause a specific operation
     pub fn pause(env: &Env, operation: u32) -> Result<(), GuardError> {
         Self::set_pause_state(env, operation, true)
-    /// Public wrapper to validate a set of approvers against the stored threshold.
+    }
+
     pub fn validate_multi_sig(env: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
-        Self::check_multi_sig(&env, &approvers)
+        EmergencyGuard::check_multi_sig(&env, &approvers).map(|_| ())
     }
 }

--- a/web/components/InvocationHistorySidebar.tsx
+++ b/web/components/InvocationHistorySidebar.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronLeft, ChevronRight, Clock, CheckCircle, XCircle, Trash2 } from 'lucide-react';
+import { useInvocationHistory } from './InnovocationHistory';
+import type { InvocationResult } from '../lib/sorobantypes';
+
+interface InvocationHistorySidebarProps {
+  onSelectResult: (result: InvocationResult) => void;
+}
+
+function formatTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  const today = new Date();
+  if (date.toDateString() === today.toDateString()) return 'Today';
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  if (date.toDateString() === yesterday.toDateString()) return 'Yesterday';
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+export function InvocationHistorySidebar({ onSelectResult }: InvocationHistorySidebarProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const { history, clearHistory } = useInvocationHistory();
+
+  return (
+    <div style={{ position: 'relative', display: 'flex', alignItems: 'flex-start' }}>
+      {/* Toggle button */}
+      <button
+        onClick={() => setIsOpen((prev) => !prev)}
+        title={isOpen ? 'Hide history' : 'Show history'}
+        style={{
+          position: 'absolute',
+          top: '16px',
+          left: '-14px',
+          zIndex: 10,
+          width: '28px',
+          height: '28px',
+          borderRadius: '50%',
+          backgroundColor: '#161b22',
+          border: '1px solid #30363d',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#8b949e',
+          flexShrink: 0,
+        }}
+      >
+        {isOpen ? <ChevronRight size={14} /> : <ChevronLeft size={14} />}
+      </button>
+
+      {isOpen && (
+        <div
+          style={{
+            width: '248px',
+            backgroundColor: '#161b22',
+            border: '1px solid #30363d',
+            borderRadius: '8px',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+            maxHeight: '680px',
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              padding: '12px 14px',
+              borderBottom: '1px solid #30363d',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              flexShrink: 0,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: '7px' }}>
+              <Clock size={13} color="#8b949e" />
+              <span style={{ fontSize: '13px', fontWeight: '600', color: '#c9d1d9' }}>
+                History
+              </span>
+              {history.length > 0 && (
+                <span
+                  style={{
+                    fontSize: '11px',
+                    backgroundColor: '#21262d',
+                    color: '#8b949e',
+                    borderRadius: '10px',
+                    padding: '1px 6px',
+                    lineHeight: '16px',
+                  }}
+                >
+                  {history.length}
+                </span>
+              )}
+            </div>
+
+            {history.length > 0 && (
+              <button
+                onClick={clearHistory}
+                title="Clear all history"
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: '#8b949e',
+                  padding: '2px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  borderRadius: '4px',
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.color = '#f85149'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.color = '#8b949e'; }}
+              >
+                <Trash2 size={12} />
+              </button>
+            )}
+          </div>
+
+          {/* List */}
+          <div style={{ overflowY: 'auto', flex: 1 }}>
+            {history.length === 0 ? (
+              <div
+                style={{
+                  padding: '40px 16px',
+                  textAlign: 'center',
+                  color: '#8b949e',
+                  fontSize: '12px',
+                }}
+              >
+                <Clock size={22} color="#30363d" style={{ margin: '0 auto 10px', display: 'block' }} />
+                No analyses yet
+              </div>
+            ) : (
+              history.map((item, index) => {
+                const report = item.analysisReport ?? (item as any).resourceCost;
+
+                return (
+                  <button
+                    key={item.id}
+                    onClick={() => onSelectResult(item)}
+                    style={{
+                      width: '100%',
+                      padding: '10px 14px',
+                      backgroundColor: 'transparent',
+                      border: 'none',
+                      borderBottom: index < history.length - 1 ? '1px solid #21262d' : 'none',
+                      textAlign: 'left',
+                      cursor: 'pointer',
+                      display: 'block',
+                      transition: 'background-color 0.12s',
+                    }}
+                    onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#1c2128'; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
+                  >
+                    <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start' }}>
+                      <div style={{ paddingTop: '1px', flexShrink: 0 }}>
+                        {item.success ? (
+                          <CheckCircle size={13} color="#3fb950" />
+                        ) : (
+                          <XCircle size={13} color="#f85149" />
+                        )}
+                      </div>
+
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <p
+                          style={{
+                            margin: '0 0 2px 0',
+                            fontSize: '12px',
+                            fontWeight: '500',
+                            color: '#c9d1d9',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {item.functionName}
+                        </p>
+
+                        <p style={{ margin: '0', fontSize: '11px', color: '#8b949e' }}>
+                          {formatDate(item.timestamp)} · {formatTime(item.timestamp)}
+                        </p>
+
+                        {report && item.success && (
+                          <p
+                            style={{
+                              margin: '3px 0 0 0',
+                              fontSize: '11px',
+                              color: '#00d9ff',
+                              fontFamily: 'monospace',
+                            }}
+                          >
+                            {(report.cpu_instructions / 1_000_000).toFixed(1)}M CPU
+                            {' · '}
+                            {(report.ram_bytes / 1024).toFixed(0)} KB
+                          </p>
+                        )}
+
+                        {item.error && (
+                          <p
+                            style={{
+                              margin: '3px 0 0 0',
+                              fontSize: '11px',
+                              color: '#f85149',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {item.error}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import { useState, useEffect } from 'react';
 import { ResultViewer } from '../components/Resultviewer';
 import { InvocationHistory, useInvocationHistory } from '../components/InnovocationHistory';
+import { InvocationHistorySidebar } from '../components/InvocationHistorySidebar';
 import { NutritionLabel } from '../components/NutritionLabel';
 import { FunctionSidebar } from '../components/FunctionSidebar';
 import { ContractInteraction } from '../components/ContractInteraction';
@@ -405,7 +406,8 @@ export default function Home() {
           )}
         </div>
 
-        <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <div className="mb-6 flex gap-6 items-start">
+          <div className="flex-1 grid grid-cols-1 gap-6 lg:grid-cols-2 min-w-0">
           {/* Left Column - Function Selection & Form */}
           <div>
             <FunctionSidebar
@@ -558,6 +560,13 @@ export default function Home() {
               )}
             </div>
           </div>
+          </div>
+          <InvocationHistorySidebar
+            onSelectResult={(result) => {
+              setCurrentResult(result);
+              setTab('explorer');
+            }}
+          />
         </div>
 
         {/* Info Cards */}


### PR DESCRIPTION
 ## Summary

- **FE — Invocation History Sidebar**: Added `InvocationHistorySidebar` component (`web/components/InvocationHistorySidebar.tsx`), a collapsible panel that lists previous contract analyses. Each item shows the function name, timestamp, success/failure indicator, and a CPU/RAM summary. Clicking any entry loads that result directly into the dashboard. The sidebar is rendered alongside the main content grid in `pages/index.tsx` using the existing `useInvocationHistory` hook for shared state.

- **Contracts — Enhanced EmergencyGuard event logging**: Added `signatures_count: u32` to `EmergencyGuardEvent` (number of valid unique admin signatures verified, distinct from the raw `approver_count`). Updated all legacy per-action event structs (`GuardInitializedEvent`, `PauseStateChangedEvent`, `EmergencyPausedEvent`, `ResumedEvent`, `AdminAddedEvent`, `AdminRemovedEvent`) to also carry `admin_count` and `signatures_count`, so every emitted event contains the full guard context. Changed `check_multi_sig` to return `Result<u32, GuardError>` so callers capture the verified count and propagate it into event payloads. Also fixed broken brace structure and `DataKey`/`GuardDataKey` inconsistencies left by prior merge conflicts.

Fixes #412
Fixes #410 