### PR TITLE
fix: Ensure EmergencyGuardEvent is published correctly on pause/unpause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crucible-example-gasless"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/emergency_guard/examples/simple_token.rs
+++ b/contracts/emergency_guard/examples/simple_token.rs
@@ -1,6 +1,6 @@
 #![no_std]
-use emergency_guard::{EmergencyGuard, PauseType};
-use soroban_sdk::{contract, contractimpl, contracttype, vec, Address, Env};
+use emergency_guard::{EmergencyGuard, DefaultEmergencyGuard, EmergencyGuardTrait, PauseType};
+use soroban_sdk::{contract, contractimpl, contracttype, vec, Address, Env, Vec};
 
 #[contracttype]
 pub enum DataKey {
@@ -163,8 +163,8 @@ impl SimpleToken {
     }
 
     /// Emergency: pause all operations
-    pub fn emergency_pause_all(env: Env) {
-        DefaultEmergencyGuard::emergency_pause_all(&env).expect("Unauthorized");
+    pub fn emergency_pause_all(env: Env, approvers: Vec<Address>) {
+        DefaultEmergencyGuard::emergency_pause_all(&env, approvers).expect("Unauthorized");
     }
 
     /// Resume all operations
@@ -195,20 +195,20 @@ impl SimpleToken {
     }
 
     /// Add new admin (requires existing admin authorization)
-    pub fn add_admin(env: Env, new_admin: Address) {
-        DefaultEmergencyGuard::add_admin(&env, new_admin)
+    pub fn add_admin(env: Env, approvers: Vec<Address>, new_admin: Address) {
+        DefaultEmergencyGuard::add_admin(&env, approvers, new_admin)
             .expect("Unauthorized or threshold would be violated");
     }
 
     /// Remove admin
-    pub fn remove_admin(env: Env, admin: Address) {
-        DefaultEmergencyGuard::remove_admin(&env, admin)
+    pub fn remove_admin(env: Env, approvers: Vec<Address>, admin: Address) {
+        DefaultEmergencyGuard::remove_admin(&env, approvers, admin)
             .expect("Unauthorized or threshold would be violated");
     }
 
     /// Rotate admin (current admin transfers authority to new admin)
-    pub fn rotate_admin(env: Env, new_admin: Address) {
-        DefaultEmergencyGuard::rotate_admin(&env, new_admin).expect("Unauthorized");
+    pub fn rotate_admin(env: Env, approvers: Vec<Address>, old_admin: Address, new_admin: Address) {
+        DefaultEmergencyGuard::rotate_admin(&env, approvers, old_admin, new_admin).expect("Unauthorized");
     }
 
     // ==== READ-ONLY FUNCTIONS ====

--- a/contracts/emergency_guard/src/lib.rs
+++ b/contracts/emergency_guard/src/lib.rs
@@ -3,9 +3,7 @@
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, log, Address, Env, String, Vec,
 };
-#[cfg(feature = "contract")]
-use soroban_sdk::{contract, contractimpl};
-use soroban_sdk::{contracterror, contracttype, Address, Env, String, Vec};
+use GuardDataKey as DataKey;
 
 /// Granular pause types using bitmask for efficient storage
 /// Each bit represents a different pausable operation
@@ -130,6 +128,8 @@ fn emit_guard_event(env: &Env, event: EmergencyGuardEvent) {
         ),
         event,
     );
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GuardInitializedEvent {
@@ -284,7 +284,6 @@ pub fn emit_admin_removed(e: &Env, approvers: &Vec<Address>, admin: &Address) {
     );
 }
 
-#[contract]
 #[cfg_attr(feature = "contract", contract)]
 pub struct EmergencyGuard;
 
@@ -381,7 +380,7 @@ impl EmergencyGuard {
             &env,
             EmergencyGuardEvent {
                 action: EmergencyGuardAction::PauseSet,
-                admin: Some(admin),
+                admin: Some(admin.clone()),
                 operation,
                 paused,
                 threshold: Self::get_threshold(env.clone()),
@@ -394,6 +393,7 @@ impl EmergencyGuard {
             "Pause state updated: op={}, paused={}",
             operation,
             paused
+        );
         emit_pause_state_changed(&env, &admin, operation, paused);
         // Emit standardized EmergencyGuard event
         env.events().publish(
@@ -428,6 +428,7 @@ impl EmergencyGuard {
                 admin_count: Self::get_admins(env.clone()).len(),
                 approver_count: approvers.len(),
             },
+        );
         emit_emergency_paused_all(&env, &approvers);
         env.events().publish(
             (String::from_str(
@@ -460,6 +461,7 @@ impl EmergencyGuard {
                 admin_count: Self::get_admins(env.clone()).len(),
                 approver_count: approvers.len(),
             },
+        );
         emit_resumed_all(&env, &approvers);
         env.events().publish(
             (String::from_str(&env, "emergency_guard.resume_all"),),
@@ -492,6 +494,7 @@ impl EmergencyGuard {
                     admin_count: admins.len(),
                     approver_count: approvers.len(),
                 },
+            );
             emit_admin_added(&env, &approvers, &new_admin);
             env.storage().instance().set(&GuardDataKey::Admins, &admins);
             env.events().publish(
@@ -548,6 +551,7 @@ impl EmergencyGuard {
                 admin_count: new_admins.len(),
                 approver_count: approvers.len(),
             },
+        );
         emit_admin_removed(&env, &approvers, &admin);
         env.storage().instance().set(&GuardDataKey::Admins, &new_admins);
         env.events().publish(
@@ -850,6 +854,43 @@ impl EmergencyGuardTrait for DefaultEmergencyGuard {
         Ok(())
     }
 
+    /// Rotate admin (multi-sig required)
+    fn rotate_admin(
+        env: &Env,
+        approvers: Vec<Address>,
+        old_admin: Address,
+        new_admin: Address,
+    ) -> Result<(), GuardError> {
+        EmergencyGuard::check_multi_sig(env, &approvers)?;
+
+        let admins = Self::get_admins(env);
+        let threshold = Self::get_threshold(env);
+
+        let mut found = false;
+        let mut new_admins = soroban_sdk::Vec::new(env);
+        for a in admins.iter() {
+            if a == old_admin {
+                found = true;
+            } else if a != new_admin {
+                new_admins.push_back(a);
+            }
+        }
+
+        if !found {
+            return Err(GuardError::AdminNotFound);
+        }
+
+        new_admins.push_back(new_admin.clone());
+
+        if (new_admins.len() as u32) < threshold {
+            return Err(GuardError::InvalidThreshold);
+        }
+
+        env.storage().instance().set(&DataKey::Admins, &new_admins);
+        log!(env, "Admin rotated: {} to {}", old_admin, new_admin);
+        Ok(())
+    }
+
     /// Get list of current admins
     fn get_admins(env: &Env) -> Vec<Address> {
         env.storage()
@@ -910,8 +951,13 @@ impl DefaultEmergencyGuard {
     /// Pause a specific operation
     pub fn pause(env: &Env, operation: u32) -> Result<(), GuardError> {
         Self::set_pause_state(env, operation, true)
+    }
+
     /// Public wrapper to validate a set of approvers against the stored threshold.
     pub fn validate_multi_sig(env: Env, approvers: Vec<Address>) -> Result<(), GuardError> {
-        Self::check_multi_sig(&env, &approvers)
+        EmergencyGuard::check_multi_sig(&env, &approvers)
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/contracts/emergency_guard/src/test.rs
+++ b/contracts/emergency_guard/src/test.rs
@@ -2,23 +2,23 @@
 
 use crate::{
     AdminAddedEvent, AdminRemovedEvent, EmergencyGuard, EmergencyGuardClient, EmergencyPausedEvent,
-    GuardInitializedEvent, PauseStateChangedEvent, ResumedEvent,
+    GuardInitializedEvent, PauseStateChangedEvent, ResumedEvent, GuardError, PauseType, EmergencyGuardTrait,
+    EmergencyGuardEvent, EmergencyGuardAction,
 };
 use soroban_sdk::{
     testutils::{Address as _, Events},
-    vec, Address, Env, String as SorobanString, TryIntoVal,
+    vec, Address, Env, String, TryIntoVal,
 };
-use soroban_sdk::{testutils::Address as _, vec, Address, Env};
-use soroban_sdk::{String as SorobanString};
-
-use crate::{EmergencyGuard, EmergencyGuardClient, GuardError, PauseType};
+extern crate alloc;
+extern crate std;
+use alloc::vec::Vec;
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 fn make_admins(env: &Env, n: u32) -> soroban_sdk::Vec<Address> {
     let mut v = soroban_sdk::Vec::new(env);
     for _ in 0..n {
-        v.push_back(Address::random(env));
+        v.push_back(Address::generate(env));
     }
     v
 }
@@ -29,7 +29,7 @@ fn setup(threshold: u32, n_admins: u32) -> (Env, EmergencyGuardClient<'static>, 
     let contract_id = env.register_contract(None, EmergencyGuard);
     let client = EmergencyGuardClient::new(&env, &contract_id);
     let admins = make_admins(&env, n_admins);
-    client.initialize(&admins, &threshold).unwrap();
+    client.initialize(&admins, &threshold);
     let std_admins: Vec<Address> = admins.iter().collect();
     (env, client, std_admins)
 }
@@ -87,42 +87,48 @@ fn test_pause_all_and_unpause_all() {
 #[test]
 fn test_unpause_operation() {
     let env = Env::default();
-    let mut pause_state = crate::PauseType::new(0);
-    pause_state.set_paused(crate::PauseType::SWAP, true);
-    env.storage().instance().set(&crate::DataKey::PauseState, &pause_state);
+    let contract_id = env.register(EmergencyGuard, ());
+    env.as_contract(&contract_id, || {
+        let mut pause_state = crate::PauseType::new(0);
+        pause_state.set_paused(crate::PauseType::SWAP, true);
+        env.storage().instance().set(&crate::DataKey::PauseState, &pause_state);
 
-    crate::DefaultEmergencyGuard::unpause(&env, crate::PauseType::SWAP)
-        .expect("Failed to unpause operation");
+        crate::DefaultEmergencyGuard::unpause(&env, crate::PauseType::SWAP)
+            .expect("Failed to unpause operation");
 
-    let state: crate::PauseType = env
-        .storage()
-        .instance()
-        .get(&crate::DataKey::PauseState)
-        .unwrap_or_else(|| crate::PauseType::new(0));
-    assert!(!state.is_paused(crate::PauseType::SWAP));
+        let state: crate::PauseType = env
+            .storage()
+            .instance()
+            .get(&crate::DataKey::PauseState)
+            .unwrap_or_else(|| crate::PauseType::new(0));
+        assert!(!state.is_paused(crate::PauseType::SWAP));
+    });
 }
 
 #[test]
 fn test_unpause_all_operations() {
     let env = Env::default();
-    let mut pause_state = crate::PauseType::new(0);
-    pause_state.pause_all();
-    env.storage().instance().set(&crate::DataKey::PauseState, &pause_state);
+    let contract_id = env.register(EmergencyGuard, ());
+    env.as_contract(&contract_id, || {
+        let mut pause_state = crate::PauseType::new(0);
+        pause_state.pause_all();
+        env.storage().instance().set(&crate::DataKey::PauseState, &pause_state);
 
-    crate::DefaultEmergencyGuard::unpause_all(&env)
-        .expect("Failed to unpause all operations");
+        crate::DefaultEmergencyGuard::unpause_all(&env)
+            .expect("Failed to unpause all operations");
 
-    let state: crate::PauseType = env
-        .storage()
-        .instance()
-        .get(&crate::DataKey::PauseState)
-        .unwrap_or_else(|| crate::PauseType::new(0));
-    assert!(!state.is_paused(crate::PauseType::SWAP));
-    assert!(!state.is_paused(crate::PauseType::DEPOSIT));
-    assert!(!state.is_paused(crate::PauseType::WITHDRAW));
-    assert!(!state.is_paused(crate::PauseType::TRANSFER));
-    assert!(!state.is_paused(crate::PauseType::MINT));
-    assert!(!state.is_paused(crate::PauseType::BURN));
+        let state: crate::PauseType = env
+            .storage()
+            .instance()
+            .get(&crate::DataKey::PauseState)
+            .unwrap_or_else(|| crate::PauseType::new(0));
+        assert!(!state.is_paused(crate::PauseType::SWAP));
+        assert!(!state.is_paused(crate::PauseType::DEPOSIT));
+        assert!(!state.is_paused(crate::PauseType::WITHDRAW));
+        assert!(!state.is_paused(crate::PauseType::TRANSFER));
+        assert!(!state.is_paused(crate::PauseType::MINT));
+        assert!(!state.is_paused(crate::PauseType::BURN));
+    });
 }
 
 #[test]
@@ -154,7 +160,7 @@ fn test_initialize_rejects_zero_threshold() {
     env.mock_all_auths();
     let contract_id = env.register_contract(None, EmergencyGuard);
     let client = EmergencyGuardClient::new(&env, &contract_id);
-    let admins = vec![&env, Address::random(&env)];
+    let admins = vec![&env, Address::generate(&env)];
     let result = client.try_initialize(&admins, &0);
     assert_eq!(result, Err(Ok(GuardError::InvalidThreshold)));
 }
@@ -165,7 +171,7 @@ fn test_initialize_rejects_threshold_greater_than_admin_count() {
     env.mock_all_auths();
     let contract_id = env.register_contract(None, EmergencyGuard);
     let client = EmergencyGuardClient::new(&env, &contract_id);
-    let admins = vec![&env, Address::random(&env), Address::random(&env)];
+    let admins = vec![&env, Address::generate(&env), Address::generate(&env)];
     let result = client.try_initialize(&admins, &3);
     assert_eq!(result, Err(Ok(GuardError::InvalidThreshold)));
 }
@@ -182,9 +188,9 @@ fn test_initialize_cannot_be_called_twice() {
 #[test]
 fn test_add_admin_with_sufficient_approvers() {
     let (env, client, admins) = setup(2, 3);
-    let new_admin = Address::random(&env);
+    let new_admin = Address::generate(&env);
     let approvers = vec![&env, admins[0].clone(), admins[1].clone()];
-    client.add_admin(&approvers, &new_admin).unwrap();
+    client.add_admin(&approvers, &new_admin);
     let stored: Vec<Address> = client.get_admins().iter().collect();
     assert_eq!(stored.len(), 4);
     assert!(stored.contains(&new_admin));
@@ -193,7 +199,7 @@ fn test_add_admin_with_sufficient_approvers() {
 #[test]
 fn test_add_admin_fails_with_insufficient_approvers() {
     let (env, client, admins) = setup(2, 3);
-    let new_admin = Address::random(&env);
+    let new_admin = Address::generate(&env);
     // Only 1 approver but threshold is 2
     let approvers = vec![&env, admins[0].clone()];
     let result = client.try_add_admin(&approvers, &new_admin);
@@ -203,8 +209,8 @@ fn test_add_admin_fails_with_insufficient_approvers() {
 #[test]
 fn test_add_admin_fails_with_non_admin_approvers() {
     let (env, client, _admins) = setup(1, 2);
-    let new_admin = Address::random(&env);
-    let outsider = Address::random(&env);
+    let new_admin = Address::generate(&env);
+    let outsider = Address::generate(&env);
     let approvers = vec![&env, outsider];
     let result = client.try_add_admin(&approvers, &new_admin);
     assert_eq!(result, Err(Ok(GuardError::InsufficientSignatures)));
@@ -214,7 +220,7 @@ fn test_add_admin_fails_with_non_admin_approvers() {
 fn test_add_admin_deduplicates_approvers() {
     // Passing the same admin twice must not count as 2 approvals
     let (env, client, admins) = setup(2, 3);
-    let new_admin = Address::random(&env);
+    let new_admin = Address::generate(&env);
     let approvers = vec![&env, admins[0].clone(), admins[0].clone()];
     let result = client.try_add_admin(&approvers, &new_admin);
     assert_eq!(result, Err(Ok(GuardError::InsufficientSignatures)));
@@ -226,7 +232,7 @@ fn test_add_admin_idempotent_for_existing_admin() {
     let (env, client, admins) = setup(1, 2);
     let existing = admins[0].clone();
     let approvers = vec![&env, admins[0].clone()];
-    client.add_admin(&approvers, &existing).unwrap();
+    client.add_admin(&approvers, &existing);
     let stored: Vec<Address> = client.get_admins().iter().collect();
     assert_eq!(stored.len(), 2, "duplicate admin must not be inserted");
 }
@@ -234,9 +240,9 @@ fn test_add_admin_idempotent_for_existing_admin() {
 #[test]
 fn test_add_admin_threshold_one_single_approver_sufficient() {
     let (env, client, admins) = setup(1, 2);
-    let new_admin = Address::random(&env);
+    let new_admin = Address::generate(&env);
     let approvers = vec![&env, admins[0].clone()];
-    client.add_admin(&approvers, &new_admin).unwrap();
+    client.add_admin(&approvers, &new_admin);
     assert_eq!(client.get_admins().len(), 3);
 }
 
@@ -247,7 +253,7 @@ fn test_remove_admin_with_sufficient_approvers() {
     let (env, client, admins) = setup(2, 3);
     let to_remove = admins[2].clone();
     let approvers = vec![&env, admins[0].clone(), admins[1].clone()];
-    client.remove_admin(&approvers, &to_remove).unwrap();
+    client.remove_admin(&approvers, &to_remove);
     let stored: Vec<Address> = client.get_admins().iter().collect();
     assert_eq!(stored.len(), 2);
     assert!(!stored.contains(&to_remove));
@@ -265,7 +271,7 @@ fn test_remove_admin_fails_with_insufficient_approvers() {
 #[test]
 fn test_remove_admin_fails_when_admin_not_found() {
     let (env, client, admins) = setup(2, 3);
-    let outsider = Address::random(&env);
+    let outsider = Address::generate(&env);
     let approvers = vec![&env, admins[0].clone(), admins[1].clone()];
     let result = client.try_remove_admin(&approvers, &outsider);
     assert_eq!(result, Err(Ok(GuardError::AdminNotFound)));
@@ -284,7 +290,7 @@ fn test_remove_admin_fails_when_would_drop_below_threshold() {
 #[test]
 fn test_remove_admin_fails_with_non_admin_approvers() {
     let (env, client, admins) = setup(1, 2);
-    let outsider = Address::random(&env);
+    let outsider = Address::generate(&env);
     let approvers = vec![&env, outsider];
     let result = client.try_remove_admin(&approvers, &admins[1]);
     assert_eq!(result, Err(Ok(GuardError::InsufficientSignatures)));
@@ -295,16 +301,16 @@ fn test_remove_admin_fails_with_non_admin_approvers() {
 #[test]
 fn test_full_admin_rotation_add_then_remove_old() {
     let (env, client, admins) = setup(2, 3);
-    let new_admin = Address::random(&env);
+    let new_admin = Address::generate(&env);
 
     // Step 1: add new admin
     let approvers = vec![&env, admins[0].clone(), admins[1].clone()];
-    client.add_admin(&approvers, &new_admin).unwrap();
+    client.add_admin(&approvers, &new_admin);
     assert_eq!(client.get_admins().len(), 4);
 
     // Step 2: remove one of the original admins using new quorum
     let approvers2 = vec![&env, admins[0].clone(), new_admin.clone()];
-    client.remove_admin(&approvers2, &admins[2]).unwrap();
+    client.remove_admin(&approvers2, &admins[2]);
 
     let stored: Vec<Address> = client.get_admins().iter().collect();
     assert_eq!(stored.len(), 3);
@@ -318,10 +324,10 @@ fn test_removed_admin_cannot_approve_operations() {
 
     // Remove admins[2]
     let approvers = vec![&env, admins[0].clone()];
-    client.remove_admin(&approvers, &admins[2]).unwrap();
+    client.remove_admin(&approvers, &admins[2]);
 
     // admins[2] tries to add a new admin — should fail
-    let new_admin = Address::random(&env);
+    let new_admin = Address::generate(&env);
     let bad_approvers = vec![&env, admins[2].clone()];
     let result = client.try_add_admin(&bad_approvers, &new_admin);
     assert_eq!(result, Err(Ok(GuardError::InsufficientSignatures)));
@@ -330,14 +336,14 @@ fn test_removed_admin_cannot_approve_operations() {
 #[test]
 fn test_newly_added_admin_can_approve_operations() {
     let (env, client, admins) = setup(1, 2);
-    let new_admin = Address::random(&env);
+    let new_admin = Address::generate(&env);
 
     // Add new_admin
     let approvers = vec![&env, admins[0].clone()];
-    client.add_admin(&approvers, &new_admin).unwrap();
+    client.add_admin(&approvers, &new_admin);
 
     // new_admin approves a pause operation
-    client.set_pause(&new_admin, &PauseType::SWAP, &true).unwrap();
+    client.set_pause(&new_admin, &PauseType::SWAP, &true);
     assert!(client.is_paused(&PauseType::SWAP));
 }
 
@@ -364,7 +370,7 @@ fn test_get_threshold_returns_correct_value() {
 #[test]
 fn test_set_pause_by_single_admin() {
     let (env, client, admins) = setup(1, 2);
-    client.set_pause(&admins[0], &PauseType::DEPOSIT, &true).unwrap();
+    client.set_pause(&admins[0], &PauseType::DEPOSIT, &true);
     assert!(client.is_paused(&PauseType::DEPOSIT));
     assert!(!client.is_paused(&PauseType::SWAP));
 }
@@ -372,7 +378,7 @@ fn test_set_pause_by_single_admin() {
 #[test]
 fn test_set_pause_rejected_for_non_admin() {
     let (env, client, _admins) = setup(1, 2);
-    let outsider = Address::random(&env);
+    let outsider = Address::generate(&env);
     let result = client.try_set_pause(&outsider, &PauseType::SWAP, &true);
     assert_eq!(result, Err(Ok(GuardError::Unauthorized)));
 }
@@ -388,7 +394,7 @@ fn test_emergency_pause_requires_multi_sig() {
 
     // 2 approvers — should succeed and pause everything
     let approvers = vec![&env, admins[0].clone(), admins[1].clone()];
-    client.emergency_pause(&approvers).unwrap();
+    client.emergency_pause(&approvers);
     for op in [
         PauseType::SWAP,
         PauseType::DEPOSIT,
@@ -407,7 +413,7 @@ fn test_resume_requires_multi_sig() {
 
     // Pause everything first
     let approvers = vec![&env, admins[0].clone(), admins[1].clone()];
-    client.emergency_pause(&approvers).unwrap();
+    client.emergency_pause(&approvers);
 
     // Try resume with 1 approver — should fail
     let approvers1 = vec![&env, admins[0].clone()];
@@ -416,7 +422,7 @@ fn test_resume_requires_multi_sig() {
 
     // Resume with 2 approvers — should succeed
     let approvers2 = vec![&env, admins[0].clone(), admins[1].clone()];
-    client.resume(&approvers2).unwrap();
+    client.resume(&approvers2);
     assert!(!client.is_paused(&PauseType::SWAP));
     assert!(!client.is_paused(&PauseType::DEPOSIT));
 }
@@ -429,20 +435,21 @@ fn test_guard_events() {
     let contract_id = env.register(EmergencyGuard, ());
     let client = EmergencyGuardClient::new(&env, &contract_id);
 
-    let admin1 = Address::random(&env);
-    let admin2 = Address::random(&env);
-    let admin3 = Address::random(&env);
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    let admin3 = Address::generate(&env);
     let admins = vec![&env, admin1.clone(), admin2.clone()];
 
+    // 1. Initialize
     client.initialize(&admins, &1);
 
     let events = env.events().all();
-    let init_name = SorobanString::from_str(&env, "emergency_guard_initialized");
+    let init_name = String::from_str(&env, "emergency_guard_initialized");
     let init_event = events
         .iter()
         .find(|(_, topics, _)| {
             topics.len() == 1 && {
-                let topic_str: Result<SorobanString, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic_str: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
                 topic_str.map(|s| s == init_name).unwrap_or(false)
             }
         })
@@ -451,25 +458,31 @@ fn test_guard_events() {
     assert_eq!(init_data.admins.len(), 2);
     assert_eq!(init_data.threshold, 1);
 
+    // Assert EmergencyGuardEvent for Initialize
+    let eg_init_event = events
+        .iter()
+        .find(|(_, topics, _)| {
+            topics.len() == 2 && {
+                let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&env);
+                topic0.map(|s| s == String::from_str(&env, "EmergencyGuard")).unwrap_or(false)
+                    && topic1.map(|s| s == String::from_str(&env, "initialized")).unwrap_or(false)
+            }
+        })
+        .expect("missing EmergencyGuard initialized event");
+    let eg_init_data: EmergencyGuardEvent = eg_init_event.2.try_into_val(&env).unwrap();
+    assert_eq!(eg_init_data.action, crate::EmergencyGuardAction::Initialized);
+
+    // 2. Set Pause
     client.set_pause(&admin1, &crate::PauseType::SWAP, &true);
-    client.emergency_pause(&vec![&env, admin1.clone()]);
-    client.resume(&vec![&env, admin1.clone()]);
-    client.add_admin(&vec![&env, admin1.clone()], &admin3);
-    client.remove_admin(&vec![&env, admin1.clone()], &admin3);
 
     let events = env.events().all();
-
-    let pause_name = SorobanString::from_str(&env, "emergency_guard_pause_state_changed");
-    let emergency_name = SorobanString::from_str(&env, "emergency_guard_emergency_paused_all");
-    let resume_name = SorobanString::from_str(&env, "emergency_guard_resumed_all");
-    let add_name = SorobanString::from_str(&env, "emergency_guard_admin_added");
-    let remove_name = SorobanString::from_str(&env, "emergency_guard_admin_removed");
-
+    let pause_name = String::from_str(&env, "emergency_guard_pause_state_changed");
     let pause_event = events
         .iter()
         .find(|(_, topics, _)| {
             topics.len() == 2 && {
-                let topic_str: Result<SorobanString, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic_str: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
                 topic_str.map(|s| s == pause_name).unwrap_or(false)
             }
         })
@@ -479,11 +492,34 @@ fn test_guard_events() {
     assert_eq!(pause_data.operation, crate::PauseType::SWAP);
     assert!(pause_data.paused);
 
+    // Assert EmergencyGuardEvent for PauseSet
+    let eg_pause_event = events
+        .iter()
+        .find(|(_, topics, _)| {
+            topics.len() == 2 && {
+                let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&env);
+                topic0.map(|s| s == String::from_str(&env, "EmergencyGuard")).unwrap_or(false)
+                    && topic1.map(|s| s == String::from_str(&env, "pause_set")).unwrap_or(false)
+            }
+        })
+        .expect("missing EmergencyGuard pause_set event");
+    let eg_pause_data: EmergencyGuardEvent = eg_pause_event.2.try_into_val(&env).unwrap();
+    assert_eq!(eg_pause_data.action, crate::EmergencyGuardAction::PauseSet);
+    assert_eq!(eg_pause_data.admin, Some(admin1.clone()));
+    assert_eq!(eg_pause_data.operation, crate::PauseType::SWAP);
+    assert!(eg_pause_data.paused);
+
+    // 3. Emergency Pause
+    client.emergency_pause(&vec![&env, admin1.clone()]);
+
+    let events = env.events().all();
+    let emergency_name = String::from_str(&env, "emergency_guard_emergency_paused_all");
     let emergency_event = events
         .iter()
         .find(|(_, topics, _)| {
             topics.len() == 1 && {
-                let topic_str: Result<SorobanString, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic_str: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
                 topic_str.map(|s| s == emergency_name).unwrap_or(false)
             }
         })
@@ -491,11 +527,33 @@ fn test_guard_events() {
     let emergency_data: EmergencyPausedEvent = emergency_event.2.try_into_val(&env).unwrap();
     assert_eq!(emergency_data.approvers.len(), 1);
 
+    // Assert EmergencyGuardEvent for EmergencyPause
+    let eg_emergency_event = events
+        .iter()
+        .find(|(_, topics, _)| {
+            topics.len() == 2 && {
+                let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&env);
+                topic0.map(|s| s == String::from_str(&env, "EmergencyGuard")).unwrap_or(false)
+                    && topic1.map(|s| s == String::from_str(&env, "emergency_pause")).unwrap_or(false)
+            }
+        })
+        .expect("missing EmergencyGuard emergency_pause event");
+    let eg_emergency_data: EmergencyGuardEvent = eg_emergency_event.2.try_into_val(&env).unwrap();
+    assert_eq!(eg_emergency_data.action, crate::EmergencyGuardAction::EmergencyPause);
+    assert_eq!(eg_emergency_data.operation, u32::MAX);
+    assert!(eg_emergency_data.paused);
+
+    // 4. Resume
+    client.resume(&vec![&env, admin1.clone()]);
+
+    let events = env.events().all();
+    let resume_name = String::from_str(&env, "emergency_guard_resumed_all");
     let resume_event = events
         .iter()
         .find(|(_, topics, _)| {
             topics.len() == 1 && {
-                let topic_str: Result<SorobanString, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic_str: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
                 topic_str.map(|s| s == resume_name).unwrap_or(false)
             }
         })
@@ -503,11 +561,33 @@ fn test_guard_events() {
     let resume_data: ResumedEvent = resume_event.2.try_into_val(&env).unwrap();
     assert_eq!(resume_data.approvers.len(), 1);
 
+    // Assert EmergencyGuardEvent for Resume
+    let eg_resume_event = events
+        .iter()
+        .find(|(_, topics, _)| {
+            topics.len() == 2 && {
+                let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&env);
+                topic0.map(|s| s == String::from_str(&env, "EmergencyGuard")).unwrap_or(false)
+                    && topic1.map(|s| s == String::from_str(&env, "resume")).unwrap_or(false)
+            }
+        })
+        .expect("missing EmergencyGuard resume event");
+    let eg_resume_data: EmergencyGuardEvent = eg_resume_event.2.try_into_val(&env).unwrap();
+    assert_eq!(eg_resume_data.action, crate::EmergencyGuardAction::Resume);
+    assert_eq!(eg_resume_data.operation, u32::MAX);
+    assert!(!eg_resume_data.paused);
+
+    // 5. Add Admin
+    client.add_admin(&vec![&env, admin1.clone()], &admin3);
+
+    let events = env.events().all();
+    let add_name = String::from_str(&env, "emergency_guard_admin_added");
     let add_event = events
         .iter()
         .find(|(_, topics, _)| {
             topics.len() == 2 && {
-                let topic_str: Result<SorobanString, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic_str: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
                 topic_str.map(|s| s == add_name).unwrap_or(false)
             }
         })
@@ -515,17 +595,56 @@ fn test_guard_events() {
     let add_data: AdminAddedEvent = add_event.2.try_into_val(&env).unwrap();
     assert_eq!(add_data.new_admin, admin3);
 
+    // Assert EmergencyGuardEvent for AdminAdded
+    let eg_add_event = events
+        .iter()
+        .find(|(_, topics, _)| {
+            topics.len() == 2 && {
+                let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&env);
+                topic0.map(|s| s == String::from_str(&env, "EmergencyGuard")).unwrap_or(false)
+                    && topic1.map(|s| s == String::from_str(&env, "admin_added")).unwrap_or(false)
+            }
+        })
+        .expect("missing EmergencyGuard admin_added event");
+    let eg_add_data: EmergencyGuardEvent = eg_add_event.2.try_into_val(&env).unwrap();
+    assert_eq!(eg_add_data.action, crate::EmergencyGuardAction::AdminAdded);
+    assert_eq!(eg_add_data.admin, Some(admin3.clone()));
+
+    // 6. Remove Admin
+    client.remove_admin(&vec![&env, admin1.clone()], &admin3);
+
+    let events = env.events().all();
+    let remove_name = String::from_str(&env, "emergency_guard_admin_removed");
     let remove_event = events
         .iter()
         .find(|(_, topics, _)| {
             topics.len() == 2 && {
-                let topic_str: Result<SorobanString, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic_str: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
                 topic_str.map(|s| s == remove_name).unwrap_or(false)
             }
         })
         .expect("missing admin remove event");
     let remove_data: AdminRemovedEvent = remove_event.2.try_into_val(&env).unwrap();
     assert_eq!(remove_data.admin, admin3);
+
+    // Assert EmergencyGuardEvent for AdminRemoved
+    let eg_remove_event = events
+        .iter()
+        .find(|(_, topics, _)| {
+            topics.len() == 2 && {
+                let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&env);
+                let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&env);
+                topic0.map(|s| s == String::from_str(&env, "EmergencyGuard")).unwrap_or(false)
+                    && topic1.map(|s| s == String::from_str(&env, "admin_removed")).unwrap_or(false)
+            }
+        })
+        .expect("missing EmergencyGuard admin_removed event");
+    let eg_remove_data: EmergencyGuardEvent = eg_remove_event.2.try_into_val(&env).unwrap();
+    assert_eq!(eg_remove_data.action, crate::EmergencyGuardAction::AdminRemoved);
+    assert_eq!(eg_remove_data.admin, Some(admin3.clone()));
+}
+
 #[test]
 fn test_pause_type_as_u32_bitmask() {
     let mut pause = crate::PauseType::new(0);
@@ -546,51 +665,81 @@ fn test_event_emission_for_guard_actions() {
     let client = crate::EmergencyGuardClient::new(&e, &contract_id);
 
     // Setup admins
-    let admin1 = Address::random(&e);
-    let admin2 = Address::random(&e);
+    let admin1 = Address::generate(&e);
+    let admin2 = Address::generate(&e);
     let admins = vec![&e, admin1.clone(), admin2.clone()];
 
     // Initialize guard
     client.initialize(&admins, &1u32);
+    let events = e.events().all();
+    assert!(events.iter().any(|(_, topics, _)| {
+        topics.len() == 2 && {
+            let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&e);
+            let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&e);
+            topic0.map(|s| s == String::from_str(&e, "EmergencyGuard")).unwrap_or(false)
+                && topic1.map(|s| s == String::from_str(&e, "initialized")).unwrap_or(false)
+        }
+    }));
 
     // Call set_pause
-    client.set_pause(&admin1, &crate::PauseType::TRANSFER, &true).unwrap();
+    client.set_pause(&admin1, &crate::PauseType::TRANSFER, &true);
+    let events = e.events().all();
+    assert!(events.iter().any(|(_, topics, _)| {
+        topics.len() == 2 && {
+            let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&e);
+            let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&e);
+            topic0.map(|s| s == String::from_str(&e, "EmergencyGuard")).unwrap_or(false)
+                && topic1.map(|s| s == String::from_str(&e, "pause_set")).unwrap_or(false)
+        }
+    }));
 
     // Emergency pause all
     let approvers = vec![&e, admin1.clone()];
-    client.emergency_pause(&approvers).unwrap();
+    client.emergency_pause(&approvers);
+    let events = e.events().all();
+    assert!(events.iter().any(|(_, topics, _)| {
+        topics.len() == 2 && {
+            let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&e);
+            let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&e);
+            topic0.map(|s| s == String::from_str(&e, "EmergencyGuard")).unwrap_or(false)
+                && topic1.map(|s| s == String::from_str(&e, "emergency_pause")).unwrap_or(false)
+        }
+    }));
 
     // Resume all
-    client.resume(&approvers).unwrap();
+    client.resume(&approvers);
+    let events = e.events().all();
+    assert!(events.iter().any(|(_, topics, _)| {
+        topics.len() == 2 && {
+            let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&e);
+            let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&e);
+            topic0.map(|s| s == String::from_str(&e, "EmergencyGuard")).unwrap_or(false)
+                && topic1.map(|s| s == String::from_str(&e, "resume")).unwrap_or(false)
+        }
+    }));
 
     // Add admin
-    let new_admin = Address::random(&e);
-    client.add_admin(&approvers, &new_admin).unwrap();
+    let new_admin = Address::generate(&e);
+    client.add_admin(&approvers, &new_admin);
+    let events = e.events().all();
+    assert!(events.iter().any(|(_, topics, _)| {
+        topics.len() == 2 && {
+            let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&e);
+            let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&e);
+            topic0.map(|s| s == String::from_str(&e, "EmergencyGuard")).unwrap_or(false)
+                && topic1.map(|s| s == String::from_str(&e, "admin_added")).unwrap_or(false)
+        }
+    }));
 
     // Remove admin
-    client.remove_admin(&approvers, &new_admin).unwrap();
-
-    // Inspect events
+    client.remove_admin(&approvers, &new_admin);
     let events = e.events().all();
-
-    // Helper to find events by name
-    let find_events = |name: &str| {
-        let name_val = String::from_str(&e, name);
-        events
-            .iter()
-            .filter(|(_, topics, _)| {
-                if topics.is_empty() {
-                    return false;
-                }
-                let topic_str: Result<SorobanString, _> = topics.get(0).unwrap().try_into_val(&e);
-                topic_str.is_ok() && topic_str.unwrap() == name_val
-            })
-            .collect::<Vec<_>>()
-    };
-
-    assert!(!find_events("emergency_guard.set_pause").is_empty());
-    assert!(!find_events("emergency_guard.emergency_pause_all").is_empty());
-    assert!(!find_events("emergency_guard.resume_all").is_empty());
-    assert!(!find_events("emergency_guard.admin_added").is_empty());
-    assert!(!find_events("emergency_guard.admin_removed").is_empty());
+    assert!(events.iter().any(|(_, topics, _)| {
+        topics.len() == 2 && {
+            let topic0: Result<String, _> = topics.get(0).unwrap().try_into_val(&e);
+            let topic1: Result<String, _> = topics.get(1).unwrap().try_into_val(&e);
+            topic0.map(|s| s == String::from_str(&e, "EmergencyGuard")).unwrap_or(false)
+                && topic1.map(|s| s == String::from_str(&e, "admin_removed")).unwrap_or(false)
+        }
+    }));
 }


### PR DESCRIPTION
This PR resolves compilation issues and ensures that emergency guard events are correctly formatted and published during pause/unpause operations.

### Changes:
- **`contracts/emergency_guard/src/lib.rs`**:
  - Fixed syntax errors (missing closing braces/parentheses) in `emit_guard_event`, `set_pause`, `emergency_pause`, `resume`, `add_admin`, and `remove_admin`.
  - Removed duplicate `#[contract]` attribute macros on `EmergencyGuard` struct which caused multiple code generation collisions.
  - Mapped `DataKey` to `GuardDataKey` correctly across the library helper functions.
  - Implemented `rotate_admin` inside `DefaultEmergencyGuard` to satisfy the requirements of `EmergencyGuardTrait`.
  - Cloned the `admin` parameter inside `set_pause` to resolve the use-after-move compiler error.

- **`contracts/emergency_guard/src/test.rs`**:
  - Corrected imports for `EmergencyGuardEvent`, `EmergencyGuardAction`, `EmergencyGuardTrait`, `String`, and `Vec` (from `alloc`).
  - Replaced all calls to `Address::random` with the correct `Address::generate` test helper.
  - Fixed compile-time errors in `unwrap()` calls on generated client methods (client calls already return the inner value directly or panic on error).
  - Wrapped test database storage accesses inside `env.as_contract(...)` blocks.
  - Rewrote event assertion tests to assert events immediately after each call since events are scoped/reset across top-level client transactions in tests. Added E2E assertions verifying that `EmergencyGuardEvent` is published with correct topics (`(\"EmergencyGuard\", <action>)`) and correct data payload.

- **`contracts/emergency_guard/examples/simple_token.rs`**:
  - Imported missing `DefaultEmergencyGuard`, `EmergencyGuardTrait`, and `Vec` items.
  - Updated method signatures to correctly accept `approvers` where required.

closes #454