### PR TITLE
feat: Merkle fuzz tests & benchmarks, nonce persistent storage, Vercel deployment

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,81 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "web/**"
+      - ".github/workflows/deploy-frontend.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "web/**"
+      - ".github/workflows/deploy-frontend.yml"
+
+defaults:
+  run:
+    working-directory: ./web
+
+jobs:
+  # ── Build & lint ────────────────────────────────────────────────────────────
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Build
+        run: yarn build
+        env:
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          NEXT_TELEMETRY_DISABLED: 1
+
+  # ── Preview deploy (PRs) ────────────────────────────────────────────────────
+  deploy-preview:
+    name: Deploy Preview
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Deploy to Vercel (preview)
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./web
+          github-comment: true
+
+  # ── Production deploy (main) ────────────────────────────────────────────────
+  deploy-production:
+    name: Deploy Production
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Deploy to Vercel (production)
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: "--prod"
+          working-directory: ./web

--- a/contracts/crucible-example-gasless/Cargo.toml
+++ b/contracts/crucible-example-gasless/Cargo.toml
@@ -9,3 +9,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 soroban-sdk = "22.0.0"
 
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+

--- a/contracts/crucible-example-gasless/src/lib.rs
+++ b/contracts/crucible-example-gasless/src/lib.rs
@@ -77,9 +77,10 @@ impl Gasless {
         }
 
         // Nonce check — must match the stored next-nonce for this user.
+        // Persistent storage survives ledger archival so nonces are never lost.
         let expected_nonce: u64 = env
             .storage()
-            .instance()
+            .persistent()
             .get(&DataKey::Nonce(meta_tx.from.clone()))
             .unwrap_or(0u64);
         if meta_tx.nonce != expected_nonce {
@@ -89,10 +90,12 @@ impl Gasless {
         // Require the user's authorization (attached by the relayer).
         meta_tx.from.require_auth();
 
-        // Advance nonce.
+        // Advance nonce atomically before the transfer so a re-entrant call
+        // with the same nonce is rejected even if the token transfer panics.
+        let next_nonce = expected_nonce + 1;
         env.storage()
-            .instance()
-            .set(&DataKey::Nonce(meta_tx.from.clone()), &(expected_nonce + 1));
+            .persistent()
+            .set(&DataKey::Nonce(meta_tx.from.clone()), &next_nonce);
 
         // Execute the transfer.
         token::Client::new(&env, &meta_tx.token).transfer(
@@ -110,7 +113,7 @@ impl Gasless {
     /// Return the current nonce for `user` (the next expected nonce).
     pub fn nonce(env: Env, user: Address) -> u64 {
         env.storage()
-            .instance()
+            .persistent()
             .get(&DataKey::Nonce(user))
             .unwrap_or(0u64)
     }

--- a/contracts/crucible-example-gasless/src/test.rs
+++ b/contracts/crucible-example-gasless/src/test.rs
@@ -1,88 +1,85 @@
 #![cfg(test)]
-extern crate std;
 
-use crucible::assert_reverts;
-use crucible::prelude::*;
-
-use crate::{make_meta_tx, Gasless, GaslessClient, MetaTx};
+use crate::{Gasless, GaslessClient, MetaTx};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, IntoVal, Symbol,
+};
 
 const AMOUNT: i128 = 1_000_000;
 const BASE_TIME: u64 = 1_000_000;
-const DEADLINE: u64 = BASE_TIME + 3_600; // 1 hour from now
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+const DEADLINE: u64 = BASE_TIME + 3_600;
 
 struct Ctx {
-    pub env: MockEnv,
-    pub id: soroban_sdk::Address,
-    pub relayer: AccountHandle,
-    pub alice: AccountHandle,
-    pub bob: AccountHandle,
-    pub token: MockToken,
+    env: Env,
+    contract_id: Address,
+    relayer: Address,
+    alice: Address,
+    bob: Address,
+    token_id: Address,
 }
 
 impl Ctx {
     fn setup() -> Self {
-        let env = MockEnv::builder()
-            .at_timestamp(BASE_TIME)
-            .with_contract::<Gasless>()
-            .with_account("relayer", Stroops::xlm(100))
-            .with_account("alice", Stroops::xlm(100))
-            .with_account("bob", Stroops::xlm(100))
-            .build();
+        let env = Env::default();
+        env.ledger().with_mut(|l| {
+            l.timestamp = BASE_TIME;
+        });
 
-        let id = env.contract_id::<Gasless>();
-        let relayer = env.account("relayer");
-        let alice = env.account("alice");
-        let bob = env.account("bob");
+        let relayer = Address::generate(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
 
-        let token = MockToken::new(&env, "USDC", 6);
-        token.mint(&alice, AMOUNT * 5);
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin.clone())
+            .address();
 
         env.mock_all_auths();
-        GaslessClient::new(env.inner(), &id).initialize(&relayer);
+
+        StellarAssetClient::new(&env, &token_id).mint(&alice, &(AMOUNT * 5));
+
+        let contract_id = env.register(Gasless, ());
+        GaslessClient::new(&env, &contract_id).initialize(&relayer);
 
         Ctx {
             env,
-            id,
+            contract_id,
             relayer,
             alice,
             bob,
-            token,
+            token_id,
         }
     }
 
     fn client(&self) -> GaslessClient<'_> {
-        GaslessClient::new(self.env.inner(), &self.id)
+        GaslessClient::new(&self.env, &self.contract_id)
+    }
+
+    fn token(&self) -> TokenClient<'_> {
+        TokenClient::new(&self.env, &self.token_id)
     }
 
     fn meta_tx(&self, nonce: u64) -> MetaTx {
-        make_meta_tx(
-            self.env.inner(),
-            self.alice.clone(),
-            self.bob.clone(),
-            self.token.address(),
-            AMOUNT,
+        MetaTx {
+            from: self.alice.clone(),
+            to: self.bob.clone(),
+            token: self.token_id.clone(),
+            amount: AMOUNT,
             nonce,
-            DEADLINE,
-        )
+            deadline: DEADLINE,
+        }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[test]
 fn test_execute_transfers_tokens() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
     ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
-
-    assert_eq!(ctx.token.balance(&ctx.alice), AMOUNT * 4);
-    assert_eq!(ctx.token.balance(&ctx.bob), AMOUNT);
+    assert_eq!(ctx.token().balance(&ctx.alice), AMOUNT * 4);
+    assert_eq!(ctx.token().balance(&ctx.bob), AMOUNT);
 }
 
 #[test]
@@ -95,12 +92,13 @@ fn test_nonce_increments_after_execute() {
 }
 
 #[test]
+#[should_panic(expected = "invalid nonce")]
 fn test_replay_attack_reverts() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
     ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
-    // Replay with same nonce.
-    assert_reverts!(ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0)), "nonce");
+    // Replay with same nonce must revert.
+    ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
 }
 
 #[test]
@@ -109,44 +107,35 @@ fn test_sequential_nonces_succeed() {
     ctx.env.mock_all_auths();
     ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
     ctx.client().execute(&ctx.relayer, &ctx.meta_tx(1));
-    assert_eq!(ctx.token.balance(&ctx.bob), AMOUNT * 2);
+    assert_eq!(ctx.token().balance(&ctx.bob), AMOUNT * 2);
 }
 
 #[test]
+#[should_panic(expected = "meta-tx expired")]
 fn test_expired_meta_tx_reverts() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    // Advance time past the deadline.
-    ctx.env.advance_time(Duration::seconds(3_601));
-    assert_reverts!(
-        ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0)),
-        "expired"
-    );
+    ctx.env.ledger().with_mut(|l| {
+        l.timestamp = DEADLINE + 1;
+    });
+    ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
 }
 
 #[test]
+#[should_panic(expected = "unauthorized relayer")]
 fn test_unauthorized_relayer_reverts() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
-    // alice tries to act as relayer.
-    assert_reverts!(
-        ctx.client().execute(&ctx.alice, &ctx.meta_tx(0)),
-        "unauthorized relayer"
-    );
+    ctx.client().execute(&ctx.alice, &ctx.meta_tx(0));
 }
 
 #[test]
+#[should_panic(expected = "invalid nonce")]
 fn test_wrong_nonce_reverts() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
     // Nonce 1 is wrong when 0 is expected.
-    assert_reverts!(ctx.client().execute(&ctx.relayer, &ctx.meta_tx(1)), "nonce");
-}
-
-#[test]
-fn test_relayer_returns_correct_address() {
-    let ctx = Ctx::setup();
-    assert_eq!(ctx.client().relayer(), ctx.relayer.clone());
+    ctx.client().execute(&ctx.relayer, &ctx.meta_tx(1));
 }
 
 #[test]
@@ -157,42 +146,101 @@ fn test_nonce_starts_at_zero() {
 }
 
 #[test]
-fn test_execute_emits_event() {
+fn test_relayer_returns_correct_address() {
     let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
-    let matching = ctx
-        .env
-        .events_matching((soroban_sdk::symbol_short!("executed"),));
-    assert!(
-        !matching.is_empty(),
-        "expected executed event to be emitted"
-    );
+    assert_eq!(ctx.client().relayer(), ctx.relayer.clone());
 }
 
 #[test]
-fn test_multiple_users_independent_nonces() {
+#[should_panic(expected = "already initialized")]
+fn test_double_initialize_reverts() {
+    let ctx = Ctx::setup();
+    ctx.env.mock_all_auths();
+    ctx.client().initialize(&ctx.relayer);
+}
+
+#[test]
+fn test_multiple_users_have_independent_nonces() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();
 
-    // Give bob some tokens too.
-    ctx.token.mint(&ctx.bob, AMOUNT * 5);
+    StellarAssetClient::new(&ctx.env, &ctx.token_id).mint(&ctx.bob, &(AMOUNT * 5));
 
-    // alice executes nonce 0.
+    // alice uses nonce 0.
     ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
 
-    // bob's nonce is still 0 independently.
-    let bob_tx = make_meta_tx(
-        ctx.env.inner(),
-        ctx.bob.clone(),
-        ctx.alice.clone(),
-        ctx.token.address(),
-        AMOUNT,
-        0,
-        DEADLINE,
-    );
+    // bob's nonce is still 0 and is independent.
+    let bob_tx = MetaTx {
+        from: ctx.bob.clone(),
+        to: ctx.alice.clone(),
+        token: ctx.token_id.clone(),
+        amount: AMOUNT,
+        nonce: 0,
+        deadline: DEADLINE,
+    };
     ctx.client().execute(&ctx.relayer, &bob_tx);
 
     assert_eq!(ctx.client().nonce(&ctx.alice), 1);
     assert_eq!(ctx.client().nonce(&ctx.bob), 1);
+}
+
+#[test]
+#[should_panic(expected = "invalid nonce")]
+fn test_skipped_nonce_reverts() {
+    let ctx = Ctx::setup();
+    ctx.env.mock_all_auths();
+    // Skipping from nonce 0 to 2 must revert.
+    ctx.client().execute(&ctx.relayer, &ctx.meta_tx(2));
+}
+
+#[test]
+fn test_many_sequential_nonces() {
+    let ctx = Ctx::setup();
+    ctx.env.mock_all_auths();
+
+    // Mint enough tokens for 10 transfers.
+    StellarAssetClient::new(&ctx.env, &ctx.token_id).mint(&ctx.alice, &(AMOUNT * 10));
+
+    for nonce in 0..10u64 {
+        ctx.client().execute(&ctx.relayer, &ctx.meta_tx(nonce));
+    }
+
+    assert_eq!(ctx.client().nonce(&ctx.alice), 10);
+    assert_eq!(ctx.token().balance(&ctx.bob), AMOUNT * 10);
+}
+
+#[test]
+fn test_nonce_persists_in_persistent_storage() {
+    let ctx = Ctx::setup();
+    ctx.env.mock_all_auths();
+
+    ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
+
+    // Simulate ledger advancement — persistent storage survives.
+    ctx.env.ledger().with_mut(|l| {
+        l.sequence_number += 1_000;
+        l.timestamp += 10_000;
+    });
+
+    // Nonce must still be 1 after ledger advancement.
+    assert_eq!(ctx.client().nonce(&ctx.alice), 1);
+
+    // Replay of nonce 0 must still revert.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
+    }));
+    assert!(result.is_err(), "replay with consumed nonce must revert");
+}
+
+#[test]
+fn test_execute_emits_event() {
+    let ctx = Ctx::setup();
+    ctx.env.mock_all_auths();
+    ctx.client().execute(&ctx.relayer, &ctx.meta_tx(0));
+
+    let events = ctx.env.events().all();
+    let has_executed = events.iter().any(|(_, topics, _)| {
+        topics.len() == 1 && topics.get(0) == Some(Symbol::new(&ctx.env, "executed").into_val(&ctx.env))
+    });
+    assert!(has_executed, "expected 'executed' event");
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,3 +53,8 @@ rayon = "1.8"
 
 [dev-dependencies]
 proptest = "1.4.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "merkle_bench"
+harness = false

--- a/core/benches/merkle_bench.rs
+++ b/core/benches/merkle_bench.rs
@@ -1,0 +1,133 @@
+//! Criterion benchmarks for MerkleTree build performance.
+//!
+//! Measures build time and throughput for trees with 1 K, 10 K, 100 K, and
+//! 1 M leaves, plus proof generation and verification at representative sizes.
+//!
+//! Run with:
+//!   cargo bench -p soroscope-core
+//!
+//! HTML reports are written to target/criterion/ when the `html_reports`
+//! feature is enabled (enabled by default via Cargo.toml).
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use soroscope_core::merkle_tree::MerkleTree;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_leaves(n: usize) -> Vec<Vec<u8>> {
+    (0..n).map(|i| (i as u64).to_le_bytes().to_vec()).collect()
+}
+
+fn build_tree(n: usize) -> MerkleTree {
+    let leaves = make_leaves(n);
+    let mut tree = MerkleTree::new(32);
+    tree.build(leaves).expect("build must succeed");
+    tree
+}
+
+// ── Build benchmarks ──────────────────────────────────────────────────────────
+
+/// Measures total build time for increasingly large datasets.
+/// Sizes: 1 K, 10 K, 100 K, 1 M leaves.
+fn bench_build(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merkle/build");
+
+    // Reduce sample size for the two largest inputs to keep wall-clock time
+    // manageable while still producing statistically meaningful results.
+    group.sample_size(50);
+
+    for &n in &[1_000usize, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::new("leaves", n), &n, |b, &n| {
+            b.iter(|| build_tree(n));
+        });
+    }
+
+    // 1 M leaves: use a minimal sample count to avoid multi-minute CI runs.
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(1_000_000));
+    group.bench_with_input(BenchmarkId::new("leaves", 1_000_000), &1_000_000usize, |b, &n| {
+        b.iter(|| build_tree(n));
+    });
+
+    group.finish();
+}
+
+// ── Proof benchmarks ──────────────────────────────────────────────────────────
+
+/// Measures proof generation latency for a single leaf at various tree sizes.
+fn bench_proof_generation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merkle/proof_generation");
+    group.sample_size(50);
+
+    for &n in &[1_000usize, 10_000, 100_000] {
+        let tree = build_tree(n);
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(BenchmarkId::new("tree_size", n), &tree, |b, t| {
+            b.iter(|| t.generate_proof(0).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
+/// Measures proof verification latency.
+fn bench_proof_verification(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merkle/proof_verification");
+    group.sample_size(50);
+
+    for &n in &[1_000usize, 10_000, 100_000] {
+        let tree = build_tree(n);
+        let proof = tree.generate_proof(0).unwrap();
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(BenchmarkId::new("tree_size", n), &proof, |b, p| {
+            b.iter(|| p.verify());
+        });
+    }
+
+    group.finish();
+}
+
+/// Measures end-to-end throughput: build + generate all proofs + verify all.
+fn bench_end_to_end(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merkle/end_to_end");
+    group.sample_size(20);
+
+    for &n in &[1_000usize, 10_000] {
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::new("leaves", n), &n, |b, &n| {
+            b.iter(|| {
+                let tree = build_tree(n);
+                for i in 0..tree.leaf_count() {
+                    let proof = tree.generate_proof(i).unwrap();
+                    assert!(MerkleTree::verify_proof(&proof, &tree.root));
+                }
+                tree
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ── Root hex encoding ─────────────────────────────────────────────────────────
+
+/// Measures root hex encoding (should be O(1) but included for completeness).
+fn bench_root_hex(c: &mut Criterion) {
+    let tree = build_tree(1_000);
+    c.bench_function("merkle/root_hex", |b| {
+        b.iter(|| tree.get_root_hex());
+    });
+}
+
+// ── Registration ──────────────────────────────────────────────────────────────
+
+criterion_group!(
+    benches,
+    bench_build,
+    bench_proof_generation,
+    bench_proof_verification,
+    bench_end_to_end,
+    bench_root_hex,
+);
+criterion_main!(benches);

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "soroscope-merkle-fuzz"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.soroscope-core]
+path = ".."
+
+# Disable all default features of the parent crate that require network / DB
+# access so the fuzz targets stay fast and self-contained.
+[[bin]]
+name = "merkle_build"
+path = "fuzz_targets/merkle_build.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "merkle_proof"
+path = "fuzz_targets/merkle_proof.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "merkle_hex"
+path = "fuzz_targets/merkle_hex.rs"
+test = false
+doc = false

--- a/core/fuzz/fuzz_targets/merkle_build.rs
+++ b/core/fuzz/fuzz_targets/merkle_build.rs
@@ -1,0 +1,35 @@
+//! Fuzz target: feed arbitrary byte slices into MerkleTree::build.
+//!
+//! Run with:
+//!   cargo fuzz run merkle_build
+//!
+//! The fuzzer splits the input at 0x00 bytes to generate variable-length,
+//! variable-count leaf vectors. The builder must never panic regardless of
+//! the content, size, or number of leaves.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroscope_core::merkle_tree::MerkleTree;
+
+fuzz_target!(|data: &[u8]| {
+    // Split at null bytes to create a variable number of leaves.
+    let leaves: Vec<Vec<u8>> = data.split(|&b| b == 0x00).map(|s| s.to_vec()).collect();
+
+    if leaves.is_empty() {
+        return;
+    }
+
+    let mut tree = MerkleTree::new(32);
+    match tree.build(leaves) {
+        Ok(()) => {
+            for i in 0..tree.leaf_count() {
+                if let Ok(proof) = tree.generate_proof(i) {
+                    let _ = proof.verify();
+                    let _ = MerkleTree::verify_proof(&proof, &tree.root);
+                }
+            }
+            let _ = tree.get_root_hex();
+        }
+        Err(_) => {}
+    }
+});

--- a/core/fuzz/fuzz_targets/merkle_hex.rs
+++ b/core/fuzz/fuzz_targets/merkle_hex.rs
@@ -1,0 +1,26 @@
+//! Fuzz target: feed arbitrary strings to MerkleTree::from_hex_strings.
+//!
+//! Run with:
+//!   cargo fuzz run merkle_hex
+//!
+//! Exercises the hex-decode path with random byte content including
+//! invalid UTF-8 representations and odd-length hex strings.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroscope_core::merkle_tree::MerkleTree;
+
+fuzz_target!(|data: &[u8]| {
+    // Interpret the input as a sequence of hex strings separated by 0x00.
+    let hex_strings: Vec<String> = data
+        .split(|&b| b == 0x00)
+        .map(|s| String::from_utf8_lossy(s).into_owned())
+        .collect();
+
+    if hex_strings.is_empty() {
+        return;
+    }
+
+    // from_hex_strings must never panic regardless of input validity.
+    let _ = MerkleTree::from_hex_strings(hex_strings);
+});

--- a/core/fuzz/fuzz_targets/merkle_proof.rs
+++ b/core/fuzz/fuzz_targets/merkle_proof.rs
@@ -1,0 +1,72 @@
+//! Fuzz target: verify that proof generation and verification are panic-free
+//! under arbitrary inputs.
+//!
+//! Run with:
+//!   cargo fuzz run merkle_proof
+//!
+//! Strategy: build a tree from the first half of the input, then use the
+//! second half as raw bytes to construct a synthetic proof and attempt
+//! verification. Neither path may panic.
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroscope_core::merkle_tree::{MerkleTree, MerkleProof, ProofNode};
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 2 {
+        return;
+    }
+
+    let split = data.len() / 2;
+    let (tree_input, proof_input) = data.split_at(split);
+
+    // Build a real tree from the first half.
+    let leaves: Vec<Vec<u8>> = tree_input
+        .split(|&b| b == 0x00)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_vec())
+        .collect();
+
+    if leaves.is_empty() {
+        return;
+    }
+
+    let mut tree = MerkleTree::new(32);
+    if tree.build(leaves).is_err() {
+        return;
+    }
+
+    // Valid proof path — must never panic.
+    for i in 0..tree.leaf_count() {
+        if let Ok(proof) = tree.generate_proof(i) {
+            let _ = proof.verify();
+            let _ = MerkleTree::verify_proof(&proof, &tree.root);
+        }
+    }
+
+    // Synthetic proof from raw bytes — verify must not panic even on garbage.
+    if proof_input.len() >= 32 {
+        let mut leaf_hash = [0u8; 32];
+        leaf_hash.copy_from_slice(&proof_input[..32]);
+
+        let mut proof_nodes = Vec::new();
+        let mut cursor = &proof_input[32..];
+        while cursor.len() >= 33 {
+            let mut sibling = [0u8; 32];
+            sibling.copy_from_slice(&cursor[..32]);
+            let is_left = cursor[32] & 1 == 1;
+            proof_nodes.push(ProofNode { hash: sibling, is_left });
+            cursor = &cursor[33..];
+        }
+
+        let synthetic = MerkleProof {
+            leaf_index: 0,
+            leaf: b"fuzz".to_vec(),
+            leaf_hash,
+            root: tree.root,
+            proof: proof_nodes,
+        };
+        let _ = synthetic.verify();
+        let _ = MerkleTree::verify_proof(&synthetic, &tree.root);
+    }
+});

--- a/core/src/merkle_tree.rs
+++ b/core/src/merkle_tree.rs
@@ -392,9 +392,8 @@ mod tests {
         t2.build(data).unwrap();
         assert_eq!(t1.root, t2.root);
     }
-}
 
-    // ── #491: Even and odd leaf count tests with reference values ────────
+    // ── Even and odd leaf count tests with reference values ────────────────
 
     #[test]
     fn test_even_leaf_count_root_matches_reference() {
@@ -462,3 +461,145 @@ mod tests {
             assert!(proof.verify(), "proof for leaf {i} failed");
         }
     }
+}
+
+// ── Property-based fuzz tests for MerkleTree ──────────────────────────────────
+//
+// Run with: cargo test (as part of the normal test suite)
+// For libfuzzer-based fuzzing, see core/fuzz/fuzz_targets/merkle_build.rs
+//
+// To run with higher iteration counts:
+//   PROPTEST_CASES=10000 cargo test fuzz_
+#[cfg(test)]
+mod fuzz_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn arb_leaf() -> impl Strategy<Value = Vec<u8>> {
+        prop::collection::vec(any::<u8>(), 0..=256)
+    }
+
+    fn arb_leaves(min: usize, max: usize) -> impl Strategy<Value = Vec<Vec<u8>>> {
+        prop::collection::vec(arb_leaf(), min..=max)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(500))]
+
+        /// Builder must never panic on any non-empty input.
+        #[test]
+        fn fuzz_build_never_panics(leaves in arb_leaves(1, 64)) {
+            let mut tree = MerkleTree::new(32);
+            let _ = tree.build(leaves);
+        }
+
+        /// Empty input must return an error, never panic.
+        #[test]
+        fn fuzz_empty_input_returns_err(_dummy in any::<u8>()) {
+            let mut tree = MerkleTree::new(32);
+            prop_assert!(tree.build(vec![]).is_err());
+        }
+
+        /// Every proof produced by the builder must verify against the tree root.
+        #[test]
+        fn fuzz_all_proofs_verify(leaves in arb_leaves(1, 32)) {
+            let mut tree = MerkleTree::new(32);
+            tree.build(leaves).expect("build succeeds");
+            for i in 0..tree.leaf_count() {
+                let proof = tree.generate_proof(i).expect("proof exists");
+                prop_assert!(proof.verify(), "proof for leaf {i} failed");
+                prop_assert!(MerkleTree::verify_proof(&proof, &tree.root));
+            }
+        }
+
+        /// Root must be deterministic: same leaves always produce the same root.
+        #[test]
+        fn fuzz_build_is_deterministic(leaves in arb_leaves(1, 32)) {
+            let mut t1 = MerkleTree::new(32);
+            let mut t2 = MerkleTree::new(32);
+            t1.build(leaves.clone()).unwrap();
+            t2.build(leaves).unwrap();
+            prop_assert_eq!(t1.root, t2.root);
+        }
+
+        /// A tampered leaf hash must cause proof.verify() to return false.
+        #[test]
+        fn fuzz_tampered_leaf_invalidates_proof(leaves in arb_leaves(2, 32)) {
+            let mut tree = MerkleTree::new(32);
+            tree.build(leaves).unwrap();
+            let mut proof = tree.generate_proof(0).unwrap();
+            proof.leaf_hash[0] ^= 0xff;
+            prop_assert!(!proof.verify());
+        }
+
+        /// A tampered sibling hash must cause verify_proof to return false.
+        #[test]
+        fn fuzz_tampered_sibling_invalidates_proof(leaves in arb_leaves(2, 32)) {
+            let mut tree = MerkleTree::new(32);
+            tree.build(leaves).unwrap();
+            let mut proof = tree.generate_proof(0).unwrap();
+            if !proof.proof.is_empty() {
+                proof.proof[0].hash = [0xFFu8; 32];
+                prop_assert!(!MerkleTree::verify_proof(&proof, &tree.root));
+            }
+        }
+
+        /// All leaves in a tree of power-of-two size must produce valid proofs.
+        #[test]
+        fn fuzz_power_of_two_leaf_counts_valid(
+            log2_size in 1usize..=6usize,
+            seed in any::<u64>(),
+        ) {
+            let size = 1 << log2_size;
+            let leaves: Vec<Vec<u8>> = (0..size)
+                .map(|i| {
+                    let mut v = seed.to_le_bytes().to_vec();
+                    v.extend_from_slice(&(i as u64).to_le_bytes());
+                    v
+                })
+                .collect();
+            let mut tree = MerkleTree::new(32);
+            tree.build(leaves).unwrap();
+            for i in 0..tree.leaf_count() {
+                let proof = tree.generate_proof(i).unwrap();
+                prop_assert!(MerkleTree::verify_proof(&proof, &tree.root));
+            }
+        }
+
+        /// Duplicate leaves must not cause panics and must produce a valid tree.
+        #[test]
+        fn fuzz_duplicate_leaves_no_panic(
+            leaf in arb_leaf(),
+            count in 2usize..=16usize,
+        ) {
+            let leaves = vec![leaf; count];
+            let mut tree = MerkleTree::new(32);
+            if tree.build(leaves).is_ok() {
+                prop_assert_eq!(tree.leaf_count(), count);
+            }
+        }
+
+        /// Very large individual leaves (up to 64 KiB) must not cause panics.
+        #[test]
+        fn fuzz_large_leaf_values(
+            leaf in prop::collection::vec(any::<u8>(), 0..=65536usize),
+        ) {
+            let mut tree = MerkleTree::new(32);
+            let _ = tree.build(vec![leaf]);
+        }
+
+        /// hex-string round-trip: encode leaves to hex, build via from_hex_strings,
+        /// result must equal direct build.
+        #[test]
+        fn fuzz_hex_roundtrip(leaves in arb_leaves(1, 16)) {
+            let hex_leaves: Vec<String> = leaves.iter().map(hex::encode).collect();
+            let tree_via_hex = MerkleTree::from_hex_strings(hex_leaves);
+            let mut tree_direct = MerkleTree::new(32);
+            tree_direct.build(leaves).unwrap();
+            match tree_via_hex {
+                Ok(t) => prop_assert_eq!(t.root, tree_direct.root),
+                Err(_) => {}
+            }
+        }
+    }
+}

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,10 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "yarn build",
+  "outputDirectory": ".next",
+  "installCommand": "yarn install",
+  "devCommand": "yarn dev",
+  "env": {
+    "NEXT_TELEMETRY_DISABLED": "1"
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements four issues in a single cohesive branch:

- **#480** — Nonce tracking & replay protection: migrate `crucible-example-gasless` nonce storage from `instance()` to `persistent()` so nonces survive ledger archival; advance nonce atomically before the transfer; replace uncompilable crucible-framework tests with soroban-sdk testutils covering replay, sequential nonces, skipped nonce, expiry, multi-user independence, and ledger-advancement persistence.
- **#496** — Merkle Tree fuzz tests: `core/fuzz/` cargo-fuzz harness (three targets: `merkle_build`, `merkle_proof`, `merkle_hex`); proptest `fuzz_tests` module inside `core/src/merkle_tree.rs` (500 cases per property, CI-runnable); fix orphaned test functions that were outside `mod tests`.
- **#499** — Merkle Tree benchmarks: criterion 0.5 added to `core` dev-deps; `core/benches/merkle_bench.rs` covering build (1 K / 10 K / 100 K / 1 M leaves), proof generation, proof verification, end-to-end throughput, and root hex encoding.
- **#502** — Vercel automated deployment: `web/vercel.json` declares Next.js + yarn build; `.github/workflows/deploy-frontend.yml` runs build+lint on every PR/push (path-filtered to `web/**`), preview deploy on PRs, production deploy on main push.

## Running the new tooling

```bash
# Proptest fuzz suite (CI-integrated)
cargo test -p soroscope-core fuzz_

# cargo-fuzz targets (requires nightly + cargo-fuzz)
cargo +nightly fuzz run merkle_build  -- -max_total_time=60
cargo +nightly fuzz run merkle_proof  -- -max_total_time=60
cargo +nightly fuzz run merkle_hex    -- -max_total_time=60

# Criterion benchmarks
cargo bench -p soroscope-core
# HTML report: target/criterion/index.html
```

## Required Vercel secrets

| Secret | Description |
|--------|-------------|
| `VERCEL_TOKEN` | Vercel personal access token |
| `VERCEL_ORG_ID` | Vercel team/org ID |
| `VERCEL_PROJECT_ID` | Vercel project ID for soroscope-web |
| `NEXT_PUBLIC_API_URL` | Backend URL for production builds |

Closes #502
Closes #496
Closes #499
Closes #480