### PR TITLE
fix: resolve duplicate cargo manifest key and add client-side file ve…

### DIFF
--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -13,7 +13,7 @@ soroban-sdk = "22.0.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }
-emergency_guard = { path = "../emergency_guard", default-features = false }
+
 # We need the pool contract code for integration tests
 liquidity-pool-contract = { package = "liquidity_pool", path = "../liquidity_pool" }
 token-contract = { package = "soroban-token-contract", path = "../token" }

--- a/web/components/WasmUpload.tsx
+++ b/web/components/WasmUpload.tsx
@@ -54,8 +54,8 @@ export default function WasmUpload({
 
   //validate WASM file
   const validateWasm = (file: File): string | null => {
-    if (!file.name.endsWith(".wasm")) {
-      return "File must be a .wasm file";
+    if (!file.name.toLowerCase().endsWith(".wasm")) {
+      return "Validation Error: File must be a .wasm file";
     }
     if (file.size > maxFileSize) {
       return `File too large (max ${(maxFileSize / 1024 / 1024).toFixed(1)}MB)`;
@@ -139,6 +139,10 @@ export default function WasmUpload({
           validFiles.push(wasmFile);
         }
       });
+
+      if (invalidFiles.length > 0) {
+        alert(invalidFiles[0].error || "Validation Error: Invalid non-WASM file uploaded.");
+      }
 
       const totalFiles = [...files, ...validFiles, ...invalidFiles];
       if (totalFiles.length > maxFiles) {

--- a/web/components/upload-zone.tsx
+++ b/web/components/upload-zone.tsx
@@ -356,6 +356,7 @@ export function UploadZone({
             }
           } catch (error) {
             const errorMsg = error instanceof Error ? error.message : 'Failed to parse WASM metadata';
+            alert(errorMsg);
             setErrorMessage(errorMsg);
             setErrorDetails({
               title: 'Invalid WASM File',
@@ -403,6 +404,7 @@ export function UploadZone({
     const ext = fileName.includes('.') ? `.${fileName.split('.').pop()}` : 'unknown type';
     const customMessage = first?.errors?.[0]?.message;
     const errorMsg = `"${fileName}" was rejected — only .wasm files are accepted (got ${ext})`;
+    alert(customMessage || errorMsg);
     setErrorMessage(customMessage || errorMsg);
     setErrorDetails({
       title: 'Invalid File Type',


### PR DESCRIPTION
## Description

This PR addresses two issues related to frontend file verification and build system warnings by implementing strict WASM checks and resolving duplicate manifest dependencies.

### Resolves:
- Fixes #[389] - FE: Add Client-side File Verification for WASM MIME/Extension
- Fixes #[383] - Build: Resolve Duplicate Cargo Manifest Key for factory

## Changes Made

**Frontend (WASM File Verification):**
- **Strict Extension Checks:** Updated `validateWasm` in `WasmUpload.tsx` to strictly verify that uploaded files end with the `.wasm` extension.
- **Validation Alerts:** Implemented `alert()` notifications across the upload handlers (`WasmUpload.tsx` and `upload-zone.tsx`) to proactively notify users when an invalid non-WASM file is rejected.
- **Client-Side Parsing Fallback:** Ensured the client-side magic number scanning fallback also triggers a UI validation alert if an invalid binary is parsed.

**Build System (Factory Contract):**
- **Manifest Cleanup:** Removed the overlapping `emergency_guard` declaration from the `[dev-dependencies]` section in `contracts/factory/Cargo.toml`, as it was already specified in the primary `[dependencies]`.
- **Clean Build:** Verified that the Cargo manifest parses and runs successfully without any duplicate key warnings.

## Acceptance Criteria Met
- [x] Uploading a non-wasm file displays a validation alert message.
- [x] Factory contract `Cargo.toml` parses without error during `cargo build`/`cargo check`.
- [x] `.wasm` file restrictions are strictly enforced.

Closes #389 
Closes #383 
Closes #384 
Closes #382 